### PR TITLE
feat: MVP conversion tracking and directory SEO scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,20 @@ A mock data fallback (`lib/mock-brokers.ts`) is currently in place for local dev
 
 ## 🗺️ Current Routes
 
+**Public:**
 - `/` — Homepage / Positioning layer. Introduces the marketplace and highlights featured partners.
 - `/directory` — The core broker directory. Features client-side filtering by State, Industry, Funding Type, and Urgency.
 - `/directory/[slug]` — Individual broker profile pages. Designed as high-conversion SEO landing pages with distinct CTAs and tracked nodes.
-- `/onboarding` — Partner onboarding page featuring a Tally form placeholder.
+- `/onboarding` — Partner onboarding page featuring a Tally form.
+- `/terms` — Terms of Service and disclaimers.
+- `/privacy` — Privacy Policy.
+
+**Internal / Infrastructure:**
+- `/out` — Centralized tracking route that logs CTA clicks before 302 redirecting users.
+
+**Future (do not build yet):**
+- `/portal` — Broker dashboard and authenticated view.
+- `/admin` — Internal application review and system management.
 
 ## 🛠️ Tech Stack
 
@@ -50,6 +60,30 @@ WIX_API_KEY=your_wix_api_key
 ```
 
 *Note: If these are not provided, the app will safely fall back to local mock data.*
+
+## 📝 Notion CRM Mapping (Future Data Layer)
+
+We will map properties from Notion to the Wix CMS `BrokerProfile` model. Here is the preliminary mapping:
+
+*   **Name** -> `fullName` (Title)
+*   **Agency/Company** -> `agencyName` (Rich Text)
+*   **Slug** -> `slug` (Formula or manually set Text)
+*   **Bio/Summary** -> `shortBio` (Text)
+*   **City** -> `city` (Select or Text)
+*   **State** -> `state` (Select or Text)
+*   **Website** -> `websiteUrl` (URL)
+*   **Email** -> `publicEmail` (Email)
+*   **Why Choose Us** -> `whyChooseYou` (Text)
+*   **Industries** -> `industries` (Multi-Select)
+*   **Funding Types/Specialties** -> `fundingTypes` / `fundingSpecialties` (Multi-Select)
+*   **Speed/Urgency** -> `urgencyCategory` (Select)
+*   **Primary CTA Link** -> `primaryCtaLink` (URL)
+*   **Primary CTA Label** -> `ctaLabel` (Text)
+*   **Approval Status** -> `approvalStatus` (Select: approved, pending, rejected)
+*   **Broker Status** -> `brokerStatus` (Select: active, hidden, recruiting)
+*   **Is Active** -> `isActive` (Checkbox)
+*   **Phone Number** -> `phoneNumber` (Phone)
+*   **Profile Image** -> `profileImage` (Files & media)
 
 ## 🛣️ Next Milestones
 

--- a/app/directory/[slug]/page.tsx
+++ b/app/directory/[slug]/page.tsx
@@ -4,8 +4,33 @@ import { SectionHeading } from '@/components/SectionHeading';
 import { CTASection } from '@/components/CTASection';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { Metadata } from 'next';
 
 export const revalidate = 3600; // Revalidate at most every hour
+
+export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
+  const broker = await getBrokerBySlug(params.slug);
+
+  if (!broker) {
+    return {
+      title: 'Partner Not Found | Moonshine Capital',
+      description: 'The requested funding partner could not be found.'
+    };
+  }
+
+  const title = `${broker.fullName} | ${broker.agencyName} | Moonshine Capital`;
+  const description = broker.shortBio || `Learn more about ${broker.fullName} at ${broker.agencyName}.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'profile',
+    }
+  };
+}
 
 export async function generateStaticParams() {
   const brokers = await getBrokers();
@@ -24,8 +49,25 @@ export default async function BrokerProfilePage({ params }: { params: { slug: st
   const specialties = broker.fundingTypes || broker.fundingSpecialties || [];
   const industries = broker.industries || [];
 
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": broker.fullName,
+    "jobTitle": "Funding Partner",
+    "worksFor": {
+      "@type": "Organization",
+      "name": broker.agencyName
+    },
+    "description": broker.shortBio,
+    "url": `https://moonshinecapital.com/directory/${broker.slug}`
+  };
+
   return (
     <div className="bg-neo-white min-h-screen text-neo-black">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="max-w-7xl mx-auto px-6 md:px-12 py-8">
         <Link href="/directory" className="inline-flex items-center gap-2 font-bold uppercase tracking-widest text-sm hover:text-neo-blue transition-colors mb-8">
           <span className="text-xl leading-none">&larr;</span> Back to Directory

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -2,13 +2,39 @@ import { getBrokers } from '@/lib/brokers';
 import { DirectoryClient } from '@/components/DirectoryClient';
 import { CTASection } from '@/components/CTASection';
 
+import { Metadata } from 'next';
+
 export const revalidate = 3600; // ISR for 1 hour
+
+export const metadata: Metadata = {
+  title: 'Partner Directory | Moonshine Capital',
+  description: 'Find the right capital partner for your next move. Browse our directory of verified funding partners.',
+  openGraph: {
+    title: 'Partner Directory | Moonshine Capital',
+    description: 'Find the right capital partner for your next move. Browse our directory of verified funding partners.',
+    type: 'website',
+  },
+};
 
 export default async function DirectoryPage() {
   const brokers = await getBrokers();
 
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "itemListElement": brokers.map((broker, index) => ({
+      "@type": "ListItem",
+      "position": index + 1,
+      "url": `https://moonshinecapital.com/directory/${broker.slug}`
+    }))
+  };
+
   return (
     <div className="bg-neo-white min-h-screen text-neo-black">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="bg-neo-black text-neo-white py-16 px-6 md:px-12 border-b-4 border-neo-green">
         <div className="max-w-7xl mx-auto">
           <h1 className="text-5xl md:text-7xl font-black uppercase tracking-tighter mb-4">Partner Directory</h1>
@@ -18,7 +44,16 @@ export default async function DirectoryPage() {
         </div>
       </div>
 
-      <DirectoryClient initialBrokers={brokers} />
+      {brokers.length === 0 ? (
+        <div className="py-24 px-6 md:px-12 max-w-7xl mx-auto">
+          <div className="bg-neo-cream border-4 border-neo-black p-12 text-center shadow-brutal">
+            <h3 className="text-3xl font-black uppercase mb-4">No Partners Available</h3>
+            <p className="font-medium text-lg">We are currently onboarding new capital partners. Please check back later.</p>
+          </div>
+        </div>
+      ) : (
+        <DirectoryClient initialBrokers={brokers} />
+      )}
 
       <CTASection />
     </div>

--- a/app/out/route.ts
+++ b/app/out/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getBrokerBySlug } from '@/lib/brokers';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const brokerSlug = searchParams.get('broker');
+  const type = searchParams.get('type') || 'apply';
+  const source = searchParams.get('source') || 'unknown';
+
+  if (!brokerSlug) {
+    return NextResponse.redirect(new URL('/directory', request.url));
+  }
+
+  const broker = await getBrokerBySlug(brokerSlug);
+
+  if (!broker) {
+    return NextResponse.redirect(new URL('/directory', request.url));
+  }
+
+  // Determine destination URL
+  let destinationUrl = '/directory'; // Default fallback
+
+  if (type === 'website' && broker.websiteUrl) {
+    destinationUrl = broker.websiteUrl;
+  } else {
+    // Default to primary CTA
+    destinationUrl = broker.primaryCta?.url || broker.primaryCtaLink || broker.websiteUrl || '#';
+  }
+
+  // Log event (MVP)
+  console.log('[Tracking Event]', {
+    event: 'cta_click',
+    broker: brokerSlug,
+    type,
+    source,
+    destinationUrl,
+    timestamp: new Date().toISOString(),
+    userAgent: request.headers.get('user-agent') || 'unknown',
+    referrer: request.headers.get('referer') || 'unknown',
+  });
+
+  if (destinationUrl === '#') {
+    return NextResponse.redirect(new URL(`/directory/${brokerSlug}`, request.url));
+  }
+
+  return NextResponse.redirect(destinationUrl);
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,55 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy | Moonshine Capital',
+  description: 'Privacy Policy for Moonshine Capital Directory.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="bg-neo-white min-h-screen text-neo-black py-24 px-6 md:px-12">
+      <div className="max-w-4xl mx-auto bg-neo-cream border-4 border-neo-black p-8 md:p-12 shadow-brutal">
+        <h1 className="text-4xl md:text-5xl font-black uppercase tracking-tighter mb-8 border-b-4 border-neo-black pb-4">
+          Privacy Policy
+        </h1>
+
+        <div className="space-y-6 font-medium text-lg leading-relaxed">
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">1. Information We Collect</h2>
+            <p>
+              We collect information you provide directly to us, such as when you apply to be listed in our directory via our intake forms (e.g., Tally embeds) or communicate with us. This may include your name, email address, agency name, phone number, and professional details. We also collect automated usage data (such as IP addresses and click events) to improve our routing and analytics.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">2. How We Use Your Information</h2>
+            <p>
+              We use the collected information to review directory applications, publish approved profiles, track engagement with our partners (e.g., CTA clicks), and improve the overall functionality of the Moonshine Capital platform.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">3. Information Sharing</h2>
+            <p>
+              When you interact with a partner listed in our directory (e.g., by clicking their CTA or applying through their link), we track this engagement. Depending on the partner's integration, some basic referral information may be shared to facilitate the connection. We do not sell your personal data to unauthorized third parties. However, your public directory profile will be visible to all site visitors.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">4. Third-Party Services</h2>
+            <p>
+              Our website uses third-party services like Tally for forms and various analytics tools. These services may have their own privacy policies governing the data they collect. Furthermore, linking to a third-party broker or lender means you are subject to their respective privacy practices once you leave our site.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">5. Data Security</h2>
+            <p>
+              We implement reasonable security measures to protect your information. However, no method of transmission over the internet or electronic storage is 100% secure, and we cannot guarantee absolute security.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,55 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service | Moonshine Capital',
+  description: 'Terms of Service and disclaimers for Moonshine Capital Directory.',
+};
+
+export default function TermsPage() {
+  return (
+    <div className="bg-neo-white min-h-screen text-neo-black py-24 px-6 md:px-12">
+      <div className="max-w-4xl mx-auto bg-neo-cream border-4 border-neo-black p-8 md:p-12 shadow-brutal">
+        <h1 className="text-4xl md:text-5xl font-black uppercase tracking-tighter mb-8 border-b-4 border-neo-black pb-4">
+          Terms of Service
+        </h1>
+
+        <div className="space-y-6 font-medium text-lg leading-relaxed">
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">1. Acceptance of Terms</h2>
+            <p>
+              By accessing and using the Moonshine Capital Directory ("the Directory"), you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use our website.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">2. No Guarantees</h2>
+            <p>
+              The Directory serves solely as an informational resource connecting businesses with independent third-party funding partners and brokers. Moonshine Capital does not underwrite, guarantee, or provide any funding directly. Any agreements or transactions entered into with listed partners are solely between you and the respective partner. We make no guarantees regarding approval rates, funding amounts, or terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">3. Third-Party Links & Affiliates</h2>
+            <p>
+              This website contains links to third-party websites and brokers. Some of these links may be affiliate links, meaning Moonshine Capital may receive a commission or referral fee if you successfully secure funding or services through them. However, we are not responsible for the content, privacy policies, or practices of any third-party websites or services.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">4. User Responsibilities</h2>
+            <p>
+              You are responsible for conducting your own due diligence before entering into any financial agreements. You agree not to use the Directory for any unlawful purpose or to submit false information during the intake process.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold uppercase mb-2">5. Changes to Terms</h2>
+            <p>
+              We reserve the right to modify these terms at any time. Your continued use of the Directory following any changes indicates your acceptance of the new terms.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/BrokerCard.tsx
+++ b/components/BrokerCard.tsx
@@ -62,7 +62,7 @@ export function BrokerCard({ broker }: BrokerCardProps) {
           View Profile
         </Link>
         <a
-          href={ctaUrl}
+          href={`/out?broker=${broker.slug}&type=apply&source=directory`}
           target="_blank"
           rel="noopener noreferrer"
           data-tracking-id={broker.primaryCta?.trackingId}

--- a/components/ProfileHero.tsx
+++ b/components/ProfileHero.tsx
@@ -59,7 +59,7 @@ export function ProfileHero({ broker }: ProfileHeroProps) {
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center md:justify-start">
             <a
-              href={ctaUrl}
+              href={`/out?broker=${broker.slug}&type=apply&source=profile`}
               target="_blank"
               rel="noopener noreferrer"
               data-tracking-id={broker.primaryCta?.trackingId}
@@ -70,7 +70,7 @@ export function ProfileHero({ broker }: ProfileHeroProps) {
 
             {broker.websiteUrl && (
               <a
-                href={broker.websiteUrl}
+                href={`/out?broker=${broker.slug}&type=website&source=profile`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn-brutal text-lg px-8 py-4 bg-neo-white border-neo-black text-neo-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all text-center"

--- a/components/TallyEmbedSection.tsx
+++ b/components/TallyEmbedSection.tsx
@@ -11,16 +11,17 @@ export function TallyEmbedSection() {
           Submit your details below. We review all profiles for accuracy and operator experience before publishing to the directory.
         </p>
 
-        {/* Tally Embed Placeholder */}
-        <div className="w-full bg-neo-white border-2 border-dashed border-neo-black/50 p-12 text-center rounded-sm">
-          <p className="font-bold text-neo-black/60 uppercase tracking-widest mb-4">Tally Form Embed Area</p>
-          <div className="inline-block bg-neo-black text-neo-white px-4 py-2 font-mono text-sm">
-            &lt;iframe src="https://tally.so/embed/..." /&gt;
-          </div>
-          <p className="mt-4 text-sm font-medium text-neo-black/60">
-            (Swap this container with the actual Tally script/iframe later)
-          </p>
-        </div>
+        <iframe
+          data-tally-src="https://tally.so/embed/mOe658?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1&formEventsForwarding=1"
+          loading="lazy"
+          width="100%"
+          height="500"
+          frameBorder="0"
+          marginHeight={0}
+          marginWidth={0}
+          title="Join the Directory">
+        </iframe>
+        <script async src="https://tally.so/widgets/embed.js"></script>
       </div>
     </section>
   );

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,6 +37,7 @@ export interface BrokerProfile {
 
   profileImage?: string;
   approvalStatus: ApprovalStatus;
+  brokerStatus?: 'active' | 'hidden' | 'recruiting';
   isActive: boolean;
   phoneNumber?: string;
   featuredFlag?: boolean;

--- a/lib/wix.ts
+++ b/lib/wix.ts
@@ -23,6 +23,7 @@ interface WixBrokerResponse {
   featuredFlag?: boolean;
   profileImage?: string;
   approvalStatus: 'approved' | 'pending' | 'rejected';
+  brokerStatus?: 'active' | 'hidden' | 'recruiting';
   isActive: boolean;
   phoneNumber?: string;
   // Raw Wix CTA fields if any, we'll map them
@@ -64,7 +65,8 @@ function normalizeBroker(wixBroker: WixBrokerResponse): BrokerProfile {
 
     profileImage: wixBroker.profileImage,
     approvalStatus: wixBroker.approvalStatus,
-    isActive: wixBroker.isActive,
+    brokerStatus: wixBroker.brokerStatus || 'active',
+    isActive: wixBroker.isActive !== undefined ? wixBroker.isActive : true,
     phoneNumber: wixBroker.phoneNumber,
   };
 }


### PR DESCRIPTION
This PR completes a series of MVP infrastructure tasks according to JULES.md.

**Phase 1 — Conversion Layer:**
- Updated `/onboarding` to use the real Tally iframe.
- Implemented `/out` endpoint that resolves brokers, tracks clicks (`type`, `source`), logs them for MVP tracking, and redirects.
- Re-routed CTAs in `ProfileHero` and `BrokerCard` to utilize the new tracking node.

**Phase 2 — Data Layer:**
- Extended `lib/types.ts` and normalized `lib/wix.ts` mappings to safely handle new structure like `brokerStatus` and `urgencyCategory`.
- Documented Notion CRM mapping within `README.md`.

**Phase 3 — SEO + Metadata:**
- Exported global OpenGraph `metadata` from `/directory/page.tsx`.
- Dynamically generated metadata in `/directory/[slug]/page.tsx` for sharing specific profile pages.
- Embedded inline `application/ld+json` blocks representing `ItemList` and `Person` models for enhanced search discoverability.

**Phase 4 & 5 — Structure & Supporting Tasks:**
- Outlined Public vs. Future routes directly in the README.
- Implemented styled `/terms` and `/privacy` pages.
- Ensured graceful layout fallback if no broker profiles are available globally.

---
*PR created automatically by Jules for task [13755988489035975725](https://jules.google.com/task/13755988489035975725) started by @JFeimster*