### PR TITLE
🔒 fix: sanitize external links to prevent XSS

### DIFF
--- a/components/BrokerCard.tsx
+++ b/components/BrokerCard.tsx
@@ -1,5 +1,6 @@
 import { BrokerProfile } from '@/lib/types';
 import Link from 'next/link';
+import { sanitizeUrl } from '@/lib/utils';
 
 interface BrokerCardProps {
   broker: BrokerProfile;
@@ -46,7 +47,7 @@ export function BrokerCard({ broker }: BrokerCardProps) {
         <Link href={`/directory/${broker.slug}`} className="btn-brutal w-full bg-neo-black text-neo-white hover:bg-neo-black hover:text-neo-white border-2 border-neo-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all">
           View Profile
         </Link>
-        <a href={broker.primaryCtaLink} target="_blank" rel="noopener noreferrer" className="btn-brutal-primary w-full text-sm py-2 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all">
+        <a href={sanitizeUrl(broker.primaryCtaLink)} target="_blank" rel="noopener noreferrer" className="btn-brutal-primary w-full text-sm py-2 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all">
           {broker.ctaLabel || 'Connect'}
         </a>
       </div>

--- a/components/ProfileHero.tsx
+++ b/components/ProfileHero.tsx
@@ -1,4 +1,5 @@
 import { BrokerProfile } from '@/lib/types';
+import { sanitizeUrl } from '@/lib/utils';
 
 interface ProfileHeroProps {
   broker: BrokerProfile;
@@ -28,11 +29,11 @@ export function ProfileHero({ broker }: ProfileHeroProps) {
           <h2 className="text-xl md:text-3xl font-bold text-neo-orange uppercase tracking-wide mb-6">{broker.agencyName}</h2>
 
           <div className="flex flex-wrap gap-4">
-            <a href={broker.primaryCtaLink} target="_blank" rel="noopener noreferrer" className="btn-brutal bg-neo-white text-neo-black px-8 py-4 text-lg">
+            <a href={sanitizeUrl(broker.primaryCtaLink)} target="_blank" rel="noopener noreferrer" className="btn-brutal bg-neo-white text-neo-black px-8 py-4 text-lg">
               {broker.ctaLabel || 'Apply Now'}
             </a>
             {broker.websiteUrl && (
-              <a href={broker.websiteUrl} target="_blank" rel="noopener noreferrer" className="btn-brutal-dark px-8 py-4 text-lg">
+              <a href={sanitizeUrl(broker.websiteUrl)} target="_blank" rel="noopener noreferrer" className="btn-brutal-dark px-8 py-4 text-lg">
                 Visit Website
               </a>
             )}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Sanitizes a URL to ensure it is safe to use in an href attribute.
+ * Only allows http:// and https:// protocols to prevent javascript: and other malicious URIs.
+ */
+export function sanitizeUrl(url: string | undefined | null): string {
+  if (!url) return '#';
+
+  const trimmed = url.trim();
+
+  // Check if the URL starts with http:// or https://
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  // For this application, we expect these links to be external.
+  // If we wanted to allow internal links, we could check for / but not //
+  // However, based on the vulnerability report, we should stick to http/https.
+
+  return '#';
+}


### PR DESCRIPTION
This commit addresses a security vulnerability where user-provided links in the 'href' attribute were not sanitized, potentially allowing 'javascript:' URIs and other malicious schemes.

Changes:
- Added 'sanitizeUrl' utility in 'lib/utils.ts' to enforce http/https protocols.
- Applied 'sanitizeUrl' to 'primaryCtaLink' in 'BrokerCard' component.
- Applied 'sanitizeUrl' to 'primaryCtaLink' and 'websiteUrl' in 'ProfileHero' component.