### PR TITLE
🎨 Palette: Add skip link and filter result feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-20 - Skip Link & Dynamic Counter
+**Learning:** Adding a basic `aria-live` polite region to filter changes offers a high-value accessibility win, complementing the brutalist UI without any visual downsides. Implementing a "skip to main content" link hidden off-screen (with `sr-only focus:not-sr-only`) remains a crucial standard that wasn't previously in place.
+**Action:** Consistently recommend these low-effort, high-impact accessibility features for any dynamic list/directory view in the app. Ensure any new layout includes a skip link.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,8 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="flex flex-col min-h-screen">
+        <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 z-[100] btn-brutal-primary px-6 py-3 font-bold uppercase border-2 border-neo-black bg-neo-yellow text-neo-black shadow-brutal outline-none">
+          Skip to main content
+        </a>
         <Navbar />
-        <main className="flex-grow">
+        <main id="main-content" className="flex-grow outline-none" tabIndex={-1}>
           {children}
         </main>
         <Footer />

--- a/components/DirectoryClient.tsx
+++ b/components/DirectoryClient.tsx
@@ -40,6 +40,15 @@ export function DirectoryClient({ initialBrokers }: DirectoryClientProps) {
     return matchesSearch && matchesState && matchesSpecialty && matchesIndustry && matchesUrgency;
   });
 
+  const isAnyFilterActive = searchTerm !== '' || selectedState !== '' || selectedSpecialty !== '' || selectedIndustry !== '' || selectedUrgency !== '';
+  const clearFilters = () => {
+    setSearchTerm('');
+    setSelectedState('');
+    setSelectedSpecialty('');
+    setSelectedIndustry('');
+    setSelectedUrgency('');
+  };
+
   return (
     <div className="py-12 px-6 md:px-12 max-w-7xl mx-auto">
       <DirectoryFilters
@@ -57,6 +66,21 @@ export function DirectoryClient({ initialBrokers }: DirectoryClientProps) {
         availableSpecialties={availableSpecialties}
         availableIndustries={availableIndustries}
       />
+
+      <div className="mb-8 flex flex-col sm:flex-row justify-between items-center gap-4 bg-neo-cream p-4 border-2 border-neo-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
+        <div aria-live="polite" className="font-bold uppercase tracking-wider">
+          Showing {filteredBrokers.length} partner{filteredBrokers.length !== 1 ? 's' : ''}
+        </div>
+        {isAnyFilterActive && (
+          <button
+            onClick={clearFilters}
+            aria-label="Clear all filters"
+            className="text-xs font-black uppercase tracking-wider bg-neo-red text-neo-white border-2 border-neo-black px-4 py-2 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:translate-y-px hover:translate-x-px hover:shadow-none transition-all focus:outline-none focus:ring-2 focus:ring-neo-black"
+          >
+            Clear Filters
+          </button>
+        )}
+      </div>
 
       {filteredBrokers.length === 0 ? (
         <div className="bg-neo-cream border-4 border-neo-black p-12 text-center shadow-brutal">


### PR DESCRIPTION
💡 **What:** Added two high-impact UX/accessibility improvements:
1.  A "Skip to main content" link that appears on focus, allowing keyboard and screen-reader users to bypass the navigation.
2.  A dynamic results counter below the directory filters, complete with an `aria-live="polite"` attribute and a contextual "Clear Filters" button.

🎯 **Why:** To make the application more accessible and provide immediate, clear feedback when users interact with the directory filters. The skip link is a fundamental accessibility requirement, and the active filter count significantly reduces cognitive load.

📸 **Before/After:** The skip link remains hidden until focused. The counter fits seamlessly into the brutalist design system (yellow/cream contrast, sharp borders, bold text).

♿ **Accessibility:**
*   Added `href="#main-content"` skip link.
*   Added `tabIndex={-1}` and `id="main-content"` to the `<main>` element.
*   Added `aria-live="polite"` to the results counter so screen readers announce changes dynamically.
*   Ensured keyboard navigability for the "Clear Filters" button.

---
*PR created automatically by Jules for task [6830739210384217041](https://jules.google.com/task/6830739210384217041) started by @JFeimster*