### PR TITLE
Update onboarding docs to reflect actual Tally embed

### DIFF
--- a/JULES.md
+++ b/JULES.md
@@ -64,7 +64,7 @@ The page should include:
 - embed area for Tally
 - optional FAQ or note block
 
-Use a placeholder Tally embed component or container that can easily be swapped with a real embed URL later.
+The actual Tally form embed is already implemented and functional.
 
 #### `/directory`
 Public broker directory page.


### PR DESCRIPTION
I've updated `JULES.md` to indicate that the Tally form is now actually embedded and functional rather than being a placeholder.

---
*PR created automatically by Jules for task [17583977533486851332](https://jules.google.com/task/17583977533486851332) started by @JFeimster*