### PR TITLE
🔒 Fix XSS vulnerability via outbound redirect sanitation

### DIFF
--- a/app/out/route.ts
+++ b/app/out/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getBrokerBySlug } from '@/lib/brokers';
+import { sanitizeUrl } from '@/lib/utils';
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
@@ -21,10 +22,14 @@ export async function GET(request: NextRequest) {
   let destinationUrl = '/directory'; // Default fallback
 
   if (type === 'website' && broker.websiteUrl) {
-    destinationUrl = broker.websiteUrl;
+    destinationUrl = sanitizeUrl(broker.websiteUrl);
   } else {
     // Default to primary CTA
-    destinationUrl = broker.primaryCta?.url || broker.primaryCtaLink || broker.websiteUrl || '#';
+    destinationUrl = sanitizeUrl(broker.primaryCta?.url || broker.primaryCtaLink || broker.websiteUrl);
+  }
+
+  if (destinationUrl === '#') {
+    destinationUrl = `/directory/${brokerSlug}`;
   }
 
   // Log event (MVP)
@@ -39,9 +44,5 @@ export async function GET(request: NextRequest) {
     referrer: request.headers.get('referer') || 'unknown',
   });
 
-  if (destinationUrl === '#') {
-    return NextResponse.redirect(new URL(`/directory/${brokerSlug}`, request.url));
-  }
-
-  return NextResponse.redirect(destinationUrl);
+  return NextResponse.redirect(new URL(destinationUrl, request.url));
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,13 @@
+export function sanitizeUrl(url: string | undefined | null): string {
+  if (!url) return '#';
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.toString();
+    }
+  } catch (e) {
+    // If it doesn't parse as a full URL, we might want to check if it's a relative path,
+    // but in this context (external website URLs), we only want http/https.
+  }
+  return '#'; // Fallback for invalid/unsafe URLs
+}


### PR DESCRIPTION
This change fixes an XSS vulnerability present in the application's outbound link tracker (`app/out/route.ts`). By adding and applying a strict `sanitizeUrl` function to external, user-provided URLs (`websiteUrl`, `primaryCtaLink`), the app is protected from malicious `javascript:` or `data:` payloads while gracefully redirecting to the broker profile directory on invalid/unsafe paths.

---
*PR created automatically by Jules for task [9143748956893283470](https://jules.google.com/task/9143748956893283470) started by @JFeimster*