### PR TITLE
docs: canonical schema and data mappings for broker profiles

### DIFF
--- a/docs/FIELD_MAPPING_CONTRACT.md
+++ b/docs/FIELD_MAPPING_CONTRACT.md
@@ -4,12 +4,12 @@ This document defines the canonical data model for a Broker Profile across the D
 
 ## Merge Key
 The primary identifier for matching records across systems is the **Broker Email (`publicEmail` / `email`)**.
-Secondary fallback identifier is the **Agency Name**.
+If email is missing or changed, require manual resolution or use an immutable submission/broker ID instead.
 
 ## Field Categories
 
 ### 1. Internal-Only Fields (Notion CRM)
-- `Onboarding Status` (e.g., Pending, In Review, Approved, Rejected)
+- `Status` (e.g., Pending, In Review, Approved, Rejected)
 - `Internal Notes`
 - `Application Date`
 - `Tally Submission ID`

--- a/docs/FIELD_MAPPING_CONTRACT.md
+++ b/docs/FIELD_MAPPING_CONTRACT.md
@@ -1,0 +1,65 @@
+# Canonical Broker Schema & Field Mapping Contract
+
+This document defines the canonical data model for a Broker Profile across the Distilled Funding ecosystem. It acts as the source of truth for integrations moving data between Tally (intake), Notion (CRM), and Wix CMS (public directory).
+
+## Merge Key
+The primary identifier for matching records across systems is the **Broker Email (`publicEmail` / `email`)**.
+Secondary fallback identifier is the **Agency Name**.
+
+## Field Categories
+
+### 1. Internal-Only Fields (Notion CRM)
+- `Onboarding Status` (e.g., Pending, In Review, Approved, Rejected)
+- `Internal Notes`
+- `Application Date`
+- `Tally Submission ID`
+
+### 2. Public-Only Fields (Wix CMS)
+- `featuredFlag` (boolean, used for sorting/display)
+- `brokerStatus` (e.g., active, hidden)
+
+### 3. Derived/Generated Fields
+- `slug`: Generated from `fullName` (e.g., "Jane Doe" -> "jane-doe").
+- `primaryCtaLink`: Generated/Sanitized external URL for tracking.
+
+## Canonical Data Model
+
+| Field Name | Type | Description |
+| :--- | :--- | :--- |
+| `fullName` | String | Broker's full name. |
+| `email` | String | Broker's public contact email (Merge Key). |
+| `agencyName` | String | Name of the broker's agency. |
+| `city` | String | Operating city. |
+| `state` | String | Operating state (2-letter abbreviation). |
+| `websiteUrl` | String | Agency or broker website URL. |
+| `phoneNumber` | String | Public contact phone number. |
+| `shortBio` | String | Short professional biography. |
+| `whyChooseYou` | String | Value proposition ("Why choose this broker"). |
+| `industries` | Array<String> | Target industries. |
+| `fundingTypes` | Array<String> | Types of funding offered. |
+| `urgencyCategory` | String | Typical speed of funding ('fast', 'standard', 'complex'). |
+| `profileImage` | String (URL) | URL to broker's headshot or logo. |
+| `primaryCtaLabel`| String | Custom text for primary CTA button. |
+| `primaryCtaLink` | String (URL) | Custom destination for primary CTA button. |
+
+## Data Transformation Rules
+
+### 1. Slug Generation
+- Source: `fullName`
+- Transform: Lowercase, replace spaces with hyphens, remove special characters.
+- Example: "John Smith-Doe!" -> `john-smith-doe`
+
+### 2. URL Cleanup
+- Source: `websiteUrl`, `primaryCtaLink`, `profileImage`
+- Transform: Ensure protocol `https://` is present if missing. Remove trailing slashes.
+- Example: "example.com" -> `https://example.com`
+
+### 3. Arrays / Multi-Select Normalization
+- Source: `industries`, `fundingTypes` (Tally Multi-Select / Checkboxes)
+- Transform: Ensure comma-separated strings are parsed into arrays of trimmed strings.
+- Example: "SaaS, Manufacturing , Technology" -> `["SaaS", "Manufacturing", "Technology"]`
+
+### 4. Defaults
+- `urgencyCategory`: Default to `"standard"` if not provided.
+- `approvalStatus` (Wix): Default to `"pending"` upon initial ingestion until verified.
+- `isActive` (Wix): Default to `false` until approved.

--- a/docs/NOTION_BROKER_CRM_SCHEMA.md
+++ b/docs/NOTION_BROKER_CRM_SCHEMA.md
@@ -1,0 +1,24 @@
+# Notion Broker CRM Schema
+
+This document details the database schema for the Notion CRM used by the internal team to manage broker onboarding, reviews, and status.
+
+## Notion Database Properties
+
+| Property Name | Notion Type | Canonical Mapping | Description |
+| :--- | :--- | :--- | :--- |
+| **Broker Name** | Title | `fullName` | Broker's full name. |
+| **Email** | Email | `email` | **(Merge Key)** Broker's contact email. |
+| **Agency** | Text | `agencyName` | Broker's agency name. |
+| **Status** | Status / Select | (Internal) | Workflow state: `Pending`, `In Review`, `Approved`, `Rejected`. |
+| **Date Applied** | Date | (Internal) | Timestamp of the initial application. |
+| **State** | Select | `state` | Operating state. |
+| **Phone** | Phone | `phoneNumber` | Contact phone number. |
+| **Website** | URL | `websiteUrl` | Agency website. |
+| **Internal Notes** | Text | (Internal) | Private notes for the review team. |
+| **Profile Complete** | Checkbox | (Internal) | Automatically checked when the Profile Builder form is submitted. |
+| **Wix ID** | Text | (Internal) | ID of the synchronized Wix CMS record (used for updates). |
+| **Slug** | Text | `slug` | Generated URL slug for the public directory. |
+
+## Webhook Triggers
+- When **Status** changes to `Approved`, an n8n webhook is triggered to update the corresponding Wix CMS record (`isActive = true`, `approvalStatus = 'approved'`).
+- Changes to other fields after approval may also trigger updates to Wix CMS, depending on n8n configuration.

--- a/docs/TALLY_APPLICATION_SCHEMA.md
+++ b/docs/TALLY_APPLICATION_SCHEMA.md
@@ -14,5 +14,5 @@ This document outlines the expected fields from the initial Tally Application fo
 | **Phone Number** | Phone | `phoneNumber` | Contact phone number (Optional). |
 
 ## Notes for Ingestion (n8n Pipeline)
-- This payload creates the initial record in Notion CRM with an "Onboarding Status" of "Pending".
+- This payload creates the initial record in Notion CRM with a "Status" of "Pending".
 - No Wix CMS record is created at this stage.

--- a/docs/TALLY_APPLICATION_SCHEMA.md
+++ b/docs/TALLY_APPLICATION_SCHEMA.md
@@ -1,0 +1,18 @@
+# Tally Application Form Schema
+
+This document outlines the expected fields from the initial Tally Application form (the onboarding intake). This form is typically shorter to reduce friction, focusing on essential details to qualify a broker.
+
+## Expected Form Fields
+
+| Tally Field Label | Tally Field Type | Canonical Mapping | Description |
+| :--- | :--- | :--- | :--- |
+| **Full Name** | Short Text | `fullName` | The broker's full name. |
+| **Email Address** | Email | `email` | The broker's contact email. **(Merge Key)** |
+| **Agency Name** | Short Text | `agencyName` | The name of the broker's agency or company. |
+| **Operating State** | Dropdown / Short Text | `state` | Primary state of operation (2-letter abbreviation preferred). |
+| **Website URL** | Link / URL | `websiteUrl` | Agency or personal website URL (Optional). |
+| **Phone Number** | Phone | `phoneNumber` | Contact phone number (Optional). |
+
+## Notes for Ingestion (n8n Pipeline)
+- This payload creates the initial record in Notion CRM with an "Onboarding Status" of "Pending".
+- No Wix CMS record is created at this stage.

--- a/docs/TALLY_PROFILE_BUILDER_SCHEMA.md
+++ b/docs/TALLY_PROFILE_BUILDER_SCHEMA.md
@@ -1,0 +1,23 @@
+# Tally Profile Builder Form Schema
+
+This document outlines the expected fields from the detailed Tally Profile Builder form. This form is sent to brokers after initial intake to collect the full profile data required for the public directory.
+
+## Expected Form Fields
+
+| Tally Field Label | Tally Field Type | Canonical Mapping | Description |
+| :--- | :--- | :--- | :--- |
+| **Email Address** | Email | `email` | **(Merge Key)** Used to match this submission to the existing CRM record. |
+| **Short Bio** | Long Text | `shortBio` | Professional biography. |
+| **Why Choose You?** | Long Text | `whyChooseYou` | Value proposition for potential clients. |
+| **Operating City** | Short Text | `city` | Primary city of operation. |
+| **Target Industries** | Multiple Choice / Checkboxes | `industries` | Array of target industries (e.g., SaaS, Construction). |
+| **Funding Types** | Multiple Choice / Checkboxes | `fundingTypes` | Array of funding specialties. |
+| **Funding Speed** | Dropdown | `urgencyCategory` | Typical speed (fast, standard, complex). |
+| **Profile Image / Logo** | File Upload | `profileImage` | URL to the uploaded image. |
+| **Primary CTA Label** | Short Text | `primaryCtaLabel` | Custom text for the button (Optional). |
+| **Primary CTA Link** | Link / URL | `primaryCtaLink` | Where the button should link to (Optional). |
+
+## Notes for Ingestion (n8n Pipeline)
+- This payload updates the existing record in Notion CRM.
+- It triggers the creation/update of the corresponding Wix CMS `BrokerProfile`.
+- File uploads (images) from Tally must be securely accessible or re-hosted if necessary before passing the URL to Wix CMS.

--- a/docs/WIX_BROKERPROFILE_SCHEMA.md
+++ b/docs/WIX_BROKERPROFILE_SCHEMA.md
@@ -1,0 +1,33 @@
+# Wix CMS BrokerProfile Schema
+
+This document defines the schema for the `brokerProfiles` collection in Wix CMS. This collection is the source of truth for the public-facing Next.js directory.
+
+## Wix CMS Collection Properties
+
+| Field Key | Field Type | Frontend UI Property | Description |
+| :--- | :--- | :--- | :--- |
+| `title` | Text | (Internal) | Standard Wix title field (usually maps to Full Name). |
+| `fullName` | Text | `fullName` | The broker's full name. |
+| `publicEmail` | Text | `publicEmail` | **(Merge Key)** The public contact email for the broker. |
+| `agencyName` | Text | `agencyName` | The name of the agency. |
+| `slug` | Text | `slug` | Unique URL path segment (e.g., `jane-doe`). |
+| `shortBio` | Rich Text | `shortBio` | Professional biography. |
+| `whyChooseYou` | Rich Text | `whyChooseYou` | Value proposition. |
+| `city` | Text | `city` | Operating city. |
+| `state` | Text | `state` | Operating state (2 letters). |
+| `websiteUrl` | URL | `websiteUrl` | Agency/broker website. |
+| `phoneNumber` | Text | `phoneNumber` | Contact phone number. |
+| `industries` | Tags / Array | `industries` | List of target industries. |
+| `fundingTypes` | Tags / Array | `fundingTypes` | List of funding specialties. |
+| `urgencyCategory` | Text | `urgencyCategory` | Typical speed (`fast`, `standard`, `complex`). |
+| `profileImage` | Image | `profileImage` | Headshot or logo. |
+| `primaryCtaLabel`| Text | `primaryCta.label` | Text for the primary CTA. |
+| `primaryCtaLink` | URL | `primaryCta.url` | Destination URL for the primary CTA. |
+| `approvalStatus` | Text | `approvalStatus` | System status (`pending`, `approved`, `rejected`). |
+| `isActive` | Boolean | `isActive` | Whether the profile is live in the directory. |
+| `featuredFlag` | Boolean | `featuredFlag` | If true, prioritizes the broker in search/display. |
+| `brokerStatus` | Text | `brokerStatus` | Custom states like `active`, `hidden`, `recruiting`. |
+
+## Frontend Data Mapping Notes
+The Next.js frontend fetches records from this collection where `isActive === true` and `approvalStatus === 'approved'`.
+The frontend `lib/brokers.ts` (or equivalent) transforms these raw Wix fields into the canonical `BrokerProfile` type defined in `lib/types.ts`.


### PR DESCRIPTION
This PR addresses issue #34 by producing the foundational documentation for the canonical broker schema. It creates five markdown files in `docs/` identifying field-by-field mapping between Tally, Notion, and Wix CMS, specifying transformations, and outlining internal vs public fields. This acts as the specification needed for the n8n ingestion pipeline in upcoming issues.

---
*PR created automatically by Jules for task [11372896609740865477](https://jules.google.com/task/11372896609740865477) started by @JFeimster*