### PR TITLE
Issue #38: Remove Wix-first assumptions from documentation and architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ A Next.js App Router project for:
 ## Build priorities
 1. strengthen public directory UX
 2. keep onboarding simple and conversion-oriented
-3. preserve Wix-backed broker data abstraction
+3. preserve broker data abstraction
 4. harden tracking and analytics flow
 5. add taxonomy pages only when they support discovery
 
@@ -41,7 +41,7 @@ A Next.js App Router project for:
 - avoid duplicate docs when a system-specific schema doc already exists
 - prefer updating existing docs over creating overlapping files
 - keep CTA routing centered on `/out` unless there is a strong reason to replace it
-- keep page code dependent on `lib/brokers.ts`, not raw Wix fetch logic
+- keep page code dependent on `lib/brokers.ts`, not raw CRM/CMS fetch logic
 
 ## Recommended next build surfaces
 - `app/about/page.tsx`

--- a/JULES.md
+++ b/JULES.md
@@ -8,7 +8,8 @@ Build and extend a production-ready Next.js application for Moonshine Capital’
 
 This app powers a public-facing broker directory and profile pages while using:
 - Tally for onboarding intake
-- Wix CMS as the content/backend source of truth for broker profiles
+- Notion as the CRM and operational source of truth
+- Wix CMS as an optional read adapter
 - Vercel as the frontend hosting platform
 
 This is not a generic fintech SaaS template.
@@ -93,9 +94,9 @@ Should show brokers aligned to that funding specialty.
 ## Backend / Data Source Strategy
 
 ### Source of truth
-Use Wix CMS as the canonical data source for approved broker profiles.
+Use Notion as the canonical CRM data source, with Wix as an optional read adapter for approved broker profiles.
 
-Assume the Wix CMS collection is:
+Assume the optional Wix CMS collection is:
 `brokerProfiles`
 
 ### Public filtering rules
@@ -104,7 +105,7 @@ Only render brokers where:
 - `isActive = true`
 
 ### Data layer requirement
-Create and preserve a clean data layer abstraction so the UI does NOT directly depend on raw Wix response shapes.
+Create and preserve a clean data layer abstraction so the UI does NOT directly depend on raw CRM/CMS response shapes.
 
 Use helpers in `lib/` that:
 - fetch all approved active brokers

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -5,7 +5,7 @@
 - broker profile rendering
 - onboarding and partner intake
 - tracked outbound redirect flow
-- Wix-backed data presentation
+- Vercel/Next.js/Notion-backed data presentation
 - taxonomy-based discovery pages
 - SEO-safe page expansion
 - future portal/admin planning
@@ -32,7 +32,7 @@
 - onboarding → `app/onboarding/page.tsx`
 - CTA routing → `app/out/route.ts`
 - broker data abstraction → `lib/brokers.ts`
-- Wix integration → `lib/wix.ts`
+- Wix integration (optional downstream) → `lib/wix.ts`
 - schema / planning docs → `docs/*`
 
 ## Preferred execution style

--- a/docs/JULES_TASK_QUEUE.md
+++ b/docs/JULES_TASK_QUEUE.md
@@ -1,7 +1,7 @@
 # JULES_TASK_QUEUE
 
 ## Immediate sequence
-1. Issue #38 — shift repo fully away from Wix-first architecture
+1. Issue #38 — document repo as Vercel/Next.js/Notion-first (Wix is optional downstream adapter)
 2. Issue #39 — build public applications hub with the two active Tally forms
 3. Issue #40 — upgrade broker public profiles into useful resource hubs
 4. Issue #43 — implement embed registry loader and broker-assigned tool rendering
@@ -16,7 +16,7 @@
 
 ## Rules for Jules
 - prefer focused PRs
-- do not reopen Wix-first architecture creep
+- do not treat Wix as the required primary datastore
 - do not create catch-all monster branches
 - keep public website, portal, and admin concerns separated
 - optimize for utility, not just good-looking static pages

--- a/docs/WIX_BROKERPROFILE_SCHEMA.md
+++ b/docs/WIX_BROKERPROFILE_SCHEMA.md
@@ -13,7 +13,7 @@ For related documentation:
 - use `docs/FIELD_MAPPING_CONTRACT.md` as the master cross-system contract
 - use `docs/wix-integration.md` for integration behavior and data flow
 
-This collection is the source of truth for the public-facing Next.js directory.
+This collection is an **optional downstream read replica** for the public-facing Next.js directory. Notion CRM is the operational source of truth.
 
 ## Wix CMS Collection Properties
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -3,7 +3,7 @@
 ## Purpose
 This document defines the practical data model direction for `moonshine-capital-portal`.
 
-It is based on the current repo behavior, which centers around a broker directory backed by Wix data and rendered through Next.js App Router pages.
+It is based on the current repo behavior, which centers around a broker directory backed by Notion (with optional Wix reads) and rendered through Next.js App Router pages.
 
 **This file should be treated as the canonical app model document** for the portal repo.
 That means:
@@ -209,9 +209,9 @@ Use this file for:
 
 ---
 
-## Wix Mapping Direction
+## Notion/Wix Mapping Direction
 
-The Wix collection should remain the source of truth for approved broker profiles.
+Notion remains the operational CRM source of truth. If the optional Wix layer is used, the data maps as follows.
 
 ### Suggested field mapping
 - `Name` → `fullName`

--- a/docs/full-scaffold.md
+++ b/docs/full-scaffold.md
@@ -6,7 +6,7 @@ This document defines the corrected full scaffold for the **moonshine-capital-po
 It replaces the earlier marketplace-oriented scaffold and is now aligned to the actual repo direction:
 - broker directory
 - partner onboarding flow
-- Wix-backed broker profile presentation layer
+- optional downstream Wix publish layer
 - CTA tracking / redirect infrastructure
 - future Funding Agent OS expansion
 
@@ -29,7 +29,7 @@ A Next.js front-end for:
 **Current architectural reality:**
 - App Router project using `app/`, not `src/app/`
 - broker data comes through `lib/brokers.ts`
-- broker access is backed by Wix integration helpers
+- broker access is backed by Notion with Wix integration helpers
 - onboarding is handled through Tally embed flow
 - outbound CTAs route through a tracking redirect endpoint
 
@@ -295,7 +295,7 @@ moonshine-capital-portal/
 
 ## Notes
 - This scaffold is for **moonshine-capital-portal**, not `moonshine-partner-marketplace`.
-- Keep the portal repo anchored around the broker directory and Wix-backed profile model.
+- Keep the portal repo anchored around the broker directory and Notion/Next.js-backed profile model.
 - Do not blindly port `src/app` marketplace scaffolds into this repo; the portal currently uses `app/`.
 - Prefer adding pages that support directory discovery, onboarding, tracking, and future Funding Agent OS evolution.
 - Use this document as the source scaffold for future Codex and GitHub connector prompts.

--- a/docs/future-roadmap.md
+++ b/docs/future-roadmap.md
@@ -7,7 +7,7 @@ It is not meant to be a rigid product spec. It is a practical planning document 
 - broker discovery
 - onboarding
 - tracked outbound routing
-- Wix-backed directory presentation
+- Vercel/Next.js directory presentation
 - future Funding Agent OS expansion
 
 ---
@@ -21,7 +21,7 @@ The repo currently functions as a public-facing broker directory experience with
 - onboarding flow
 - tracked outbound redirects
 - legal pages
-- Wix-backed broker data
+- Notion-backed broker data (with optional Wix reads)
 
 This is the public discovery layer.
 
@@ -112,9 +112,9 @@ Turn the current click-tracking setup into a more usable routing and analytics l
 Make broker onboarding and publishing more systematic.
 
 ### Priorities
-- automate Tally → CRM → Wix CMS handoffs
+- automate Tally → CRM handoffs
 - add `/api/onboarding-submit`
-- add `/api/wix-sync`
+- add `/api/wix-sync` (optional)
 - strengthen profile publication rules
 - document review and merge workflows clearly
 
@@ -170,8 +170,8 @@ This repo should remain focused on:
 ### Avoid importing the wrong scaffold
 Do not blindly force `moonshine-partner-marketplace` architecture into this repo.
 
-### Keep Wix-backed profile delivery clean
-The public directory should remain decoupled from raw CMS details through the `lib/brokers.ts` abstraction.
+### Keep broker profile delivery clean
+The public directory should remain decoupled from raw CRM/CMS details through the `lib/brokers.ts` abstraction.
 
 ---
 

--- a/docs/onboarding-flow.md
+++ b/docs/onboarding-flow.md
@@ -35,7 +35,7 @@ If qualified, broker is advanced for profile completion
    ↓
 Detailed profile data is collected
    ↓
-Approved broker profile is published to Wix CMS
+Approved broker profile is read via Next.js directly or published to Wix CMS (if optional adapter used)
    ↓
 Profile appears in the public directory
 ```
@@ -70,7 +70,7 @@ Decide whether the broker should proceed toward a public profile.
 - approved
 - rejected
 
-This likely maps into the Notion CRM workflow and later Wix publishing state.
+This maps into the Notion CRM workflow.
 
 ### Stage 3 — Profile builder / enrichment
 **Goal:**
@@ -91,7 +91,7 @@ This aligns with the current profile-builder schema doc.
 
 ### Stage 4 — Publish to public directory
 **Goal:**
-Create or update the broker’s public `BrokerProfile` record in Wix CMS.
+Make the broker live on Vercel/Next.js (optionally syncing to a Wix CMS replica).
 
 **Requirements before publish:**
 - approved status
@@ -114,9 +114,10 @@ Create or update the broker’s public `BrokerProfile` record in Wix CMS.
 - Notion CRM or equivalent review system
 
 ### Public publishing layer
-- Wix CMS
-- `lib/wix.ts`
+- Vercel/Next.js
 - `lib/brokers.ts`
+- `lib/notion.ts` (future direct sync)
+- `lib/wix.ts` (optional)
 
 ---
 
@@ -150,7 +151,7 @@ Qualified broker receives the detailed profile builder form.
 Detailed content is captured and mapped into the canonical broker profile data structure.
 
 ### 6. Approval + sync
-Approved record is synced into Wix CMS with:
+Approved record is marked active in Notion (and optionally synced to Wix CMS) with:
 - `approvalStatus = approved`
 - `isActive = true`
 
@@ -188,8 +189,8 @@ Trigger detailed profile collection.
 ### Profile builder → CRM / publishing layer
 Merge enriched data into the canonical broker record.
 
-### Approved record → Wix CMS
-Create or update the live public broker profile.
+### Approved record → Public Directory
+Record becomes visible through Next.js (or is pushed to Wix CMS if the adapter is running).
 
 ---
 

--- a/docs/route-map.md
+++ b/docs/route-map.md
@@ -120,7 +120,7 @@ This route map is specific to the portal repo and its current architecture.
 - `/api/broker-click`
 - `/api/lead-intake`
 - `/api/onboarding-submit`
-- `/api/wix-sync`
+- `/api/wix-sync` (optional downstream sync)
 - `/api/webhooks/n8n`
 - `/api/webhooks/hubspot`
 
@@ -152,7 +152,7 @@ This route map is specific to the portal repo and its current architecture.
 /api/broker-click
 /api/lead-intake
 /api/onboarding-submit
-/api/wix-sync
+/api/wix-sync (optional downstream sync)
 /api/webhooks/n8n
 /api/webhooks/hubspot
 ```

--- a/docs/wix-integration.md
+++ b/docs/wix-integration.md
@@ -1,7 +1,7 @@
 # Wix Integration
 
 ## Purpose
-This document explains how `moonshine-capital-portal` uses Wix as the source-of-truth layer for broker profile data.
+This document explains how `moonshine-capital-portal` uses Wix as an optional downstream layer for broker profile data.
 
 It is meant to guide:
 - data fetching
@@ -20,12 +20,12 @@ For field-level schema details, use:
 
 ## Current Role of Wix in This Repo
 
-Wix is the current backend content source for approved broker profiles.
+Wix is an optional downstream publish/read adapter. Notion is the operational CRM and source of truth.
 
 The high-level pattern is:
-1. broker / partner data is approved externally
-2. approved records are stored in Wix CMS
-3. the Next.js portal reads those records through `lib/wix.ts`
+1. broker / partner data is approved in Notion
+2. approved records may be pushed to Wix CMS via automation
+3. the Next.js portal reads those records through `lib/wix.ts` if configured
 4. `lib/brokers.ts` acts as the local abstraction layer consumed by pages and components
 
 This keeps the app UI decoupled from the raw CMS integration.
@@ -192,7 +192,7 @@ This avoids fragile deploys.
 
 ## Security / Data Exposure Notes
 
-Wix should remain the content source, not an uncontrolled public dump.
+Wix (if used) should remain a read-only content replica, not an uncontrolled public dump.
 
 Recommended safeguards:
 - only publish approved / active brokers


### PR DESCRIPTION
This PR addresses Issue #38 by removing Wix-first assumptions from the documentation, project planning, and architectural guidelines. It establishes Notion as the primary source of truth and CRM, and Vercel/Next.js as the core application layer, positioning Wix strictly as an optional downstream read replica or publish adapter.

---
*PR created automatically by Jules for task [10700534083218211529](https://jules.google.com/task/10700534083218211529) started by @JFeimster*