### PR TITLE
Add broker utility surface

### DIFF
--- a/app/directory/[slug]/page.tsx
+++ b/app/directory/[slug]/page.tsx
@@ -1,12 +1,14 @@
 import { getBrokerBySlug, getBrokers } from '@/lib/brokers';
+import { getFeaturedRegistryItems, getToolsForBroker } from '@/lib/embed-registry';
 import { ProfileHero } from '@/components/ProfileHero';
 import { SectionHeading } from '@/components/SectionHeading';
 import { CTASection } from '@/components/CTASection';
+import { BrokerUtilitySection } from '@/components/BrokerUtilitySection';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 
-export const revalidate = 3600; // Revalidate at most every hour
+export const revalidate = 3600;
 
 export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
   const broker = await getBrokerBySlug(params.slug);
@@ -34,40 +36,32 @@ export async function generateMetadata({ params }: { params: { slug: string } })
 
 export async function generateStaticParams() {
   const brokers = await getBrokers();
-  return brokers.map((broker) => ({
-    slug: broker.slug,
-  }));
+  return brokers.map((broker) => ({ slug: broker.slug }));
 }
 
 export default async function BrokerProfilePage({ params }: { params: { slug: string } }) {
   const broker = await getBrokerBySlug(params.slug);
 
-  if (!broker) {
-    notFound();
-  }
+  if (!broker) notFound();
 
   const specialties = broker.fundingTypes || broker.fundingSpecialties || [];
   const industries = broker.industries || [];
+  const brokerTools = await getToolsForBroker(broker.slug);
+  const fallbackTools = brokerTools.length === 0 ? await getFeaturedRegistryItems(3) : [];
 
   const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    "name": broker.fullName,
-    "jobTitle": "Funding Partner",
-    "worksFor": {
-      "@type": "Organization",
-      "name": broker.agencyName
-    },
-    "description": broker.shortBio,
-    "url": `https://moonshinecapital.com/directory/${broker.slug}`
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: broker.fullName,
+    jobTitle: 'Funding Partner',
+    worksFor: { '@type': 'Organization', name: broker.agencyName },
+    description: broker.shortBio,
+    url: `https://moonshinecapital.com/directory/${broker.slug}`,
   };
 
   return (
     <div className="bg-neo-white min-h-screen text-neo-black">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <div className="max-w-7xl mx-auto px-6 md:px-12 py-8">
         <Link href="/directory" className="inline-flex items-center gap-2 font-bold uppercase tracking-widest text-sm hover:text-neo-blue transition-colors mb-8">
           <span className="text-xl leading-none">&larr;</span> Back to Directory
@@ -86,21 +80,22 @@ export default async function BrokerProfilePage({ params }: { params: { slug: st
 
             <section>
               <SectionHeading title="Snapshot" color="yellow" />
-              <p className="text-xl font-bold border-l-4 border-neo-black pl-6">
-                {broker.shortBio}
-              </p>
+              <p className="text-xl font-bold border-l-4 border-neo-black pl-6">{broker.shortBio}</p>
             </section>
+
+            <BrokerUtilitySection
+              brokerName={broker.fullName}
+              tools={brokerTools.length > 0 ? brokerTools : fallbackTools}
+              isFallback={brokerTools.length === 0}
+            />
           </div>
 
           <div className="space-y-12">
             <div className="bg-neo-black text-neo-white p-8 border-4 border-neo-green shadow-brutal">
               <h3 className="font-black text-2xl uppercase tracking-tighter mb-6 text-neo-green">Funding Types</h3>
               <ul className="space-y-3">
-                {specialties.map(spec => (
-                  <li key={spec} className="flex items-center gap-3 font-bold text-lg">
-                    <span className="w-3 h-3 bg-neo-green inline-block"></span>
-                    {spec}
-                  </li>
+                {specialties.map((spec) => (
+                  <li key={spec} className="flex items-center gap-3 font-bold text-lg"><span className="w-3 h-3 bg-neo-green inline-block"></span>{spec}</li>
                 ))}
               </ul>
 
@@ -108,11 +103,8 @@ export default async function BrokerProfilePage({ params }: { params: { slug: st
                 <>
                   <h3 className="font-black text-2xl uppercase tracking-tighter mt-8 mb-6 text-neo-pink">Industries</h3>
                   <ul className="space-y-3">
-                    {industries.map(ind => (
-                      <li key={ind} className="flex items-center gap-3 font-bold text-lg">
-                        <span className="w-3 h-3 bg-neo-pink inline-block"></span>
-                        {ind}
-                      </li>
+                    {industries.map((ind) => (
+                      <li key={ind} className="flex items-center gap-3 font-bold text-lg"><span className="w-3 h-3 bg-neo-pink inline-block"></span>{ind}</li>
                     ))}
                   </ul>
                 </>
@@ -122,22 +114,8 @@ export default async function BrokerProfilePage({ params }: { params: { slug: st
             <div className="bg-neo-cream p-8 border-4 border-neo-black shadow-brutal">
               <h3 className="font-black text-2xl uppercase tracking-tighter mb-6">Contact</h3>
               <div className="space-y-4 font-bold">
-                {broker.publicEmail && (
-                  <div>
-                    <div className="text-sm uppercase text-neo-black/60 mb-1">Email</div>
-                    <a href={`mailto:${broker.publicEmail}`} className="text-neo-blue hover:underline break-all">
-                      {broker.publicEmail}
-                    </a>
-                  </div>
-                )}
-                {broker.phoneNumber && (
-                  <div>
-                    <div className="text-sm uppercase text-neo-black/60 mb-1">Phone</div>
-                    <a href={`tel:${broker.phoneNumber}`} className="hover:underline">
-                      {broker.phoneNumber}
-                    </a>
-                  </div>
-                )}
+                {broker.publicEmail && <div><div className="text-sm uppercase text-neo-black/60 mb-1">Email</div><a href={`mailto:${broker.publicEmail}`} className="text-neo-blue hover:underline break-all">{broker.publicEmail}</a></div>}
+                {broker.phoneNumber && <div><div className="text-sm uppercase text-neo-black/60 mb-1">Phone</div><a href={`tel:${broker.phoneNumber}`} className="hover:underline">{broker.phoneNumber}</a></div>}
               </div>
             </div>
           </div>

--- a/components/BrokerUtilitySection.tsx
+++ b/components/BrokerUtilitySection.tsx
@@ -1,0 +1,31 @@
+import { ToolGrid } from '@/components/portal/ToolGrid';
+import type { ToolRegistryItem } from '@/lib/embed-registry';
+
+interface BrokerUtilitySectionProps {
+  brokerName: string;
+  tools: ToolRegistryItem[];
+  isFallback?: boolean;
+}
+
+export function BrokerUtilitySection({ brokerName, tools, isFallback = false }: BrokerUtilitySectionProps) {
+  if (tools.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <div className="inline-block border-2 border-neo-black bg-neo-yellow px-3 py-1 text-xs font-black uppercase tracking-wide shadow-[2px_2px_0_0_rgba(0,0,0,1)]">
+          Broker utility layer
+        </div>
+        <h2 className="mt-4 text-4xl font-black uppercase tracking-tight">Tools that make this profile useful</h2>
+        <p className="mt-3 max-w-3xl text-base font-medium leading-relaxed text-neo-black/75">
+          {isFallback
+            ? `${brokerName} does not have assigned tools yet, so this profile is showing the default featured tool stack.`
+            : `${brokerName}'s assigned tools and resources are wired from the shared embed registry.`}
+        </p>
+      </div>
+      <ToolGrid title={isFallback ? 'Featured default tools' : `${brokerName}'s tool stack`} tools={tools} />
+    </section>
+  );
+}

--- a/components/portal/ToolCard.tsx
+++ b/components/portal/ToolCard.tsx
@@ -1,10 +1,12 @@
-import type { ToolRegistryItem } from '@/lib/embed-registry';
+import { getRegistryDestination, type ToolRegistryItem } from '@/lib/embed-registry';
 
 interface ToolCardProps {
   tool: ToolRegistryItem;
 }
 
 export function ToolCard({ tool }: ToolCardProps) {
+  const destination = getRegistryDestination(tool);
+
   return (
     <article className="card-brutal flex h-full flex-col gap-4 bg-neo-white text-neo-black">
       <div className="flex items-start justify-between gap-4">
@@ -13,44 +15,34 @@ export function ToolCard({ tool }: ToolCardProps) {
             {tool.category}
           </div>
           <h3 className="text-2xl font-black uppercase tracking-tight">{tool.title}</h3>
+          <p className="mt-2 text-sm font-medium leading-relaxed text-neo-black/75">{tool.description}</p>
         </div>
         <span className="border border-neo-black bg-neo-pink px-2 py-1 text-xs font-black uppercase text-neo-black">
-          {tool.type}
+          {tool.resourceType}
         </span>
       </div>
 
-      <p className="text-sm font-bold uppercase text-neo-blue">
-        Access: {tool.accessLevel}
-      </p>
+      <div className="flex flex-wrap gap-2 text-xs font-black uppercase">
+        <span className="border border-neo-black bg-neo-blue px-2 py-1 text-neo-white">{tool.accessLevel}</span>
+        <span className="border border-neo-black bg-neo-green px-2 py-1 text-neo-black">{tool.renderType}</span>
+        {tool.featured && <span className="border border-neo-black bg-neo-yellow px-2 py-1 text-neo-black">featured</span>}
+      </div>
 
-      <div className="mt-auto flex flex-wrap gap-2">
-        {(tool.tags ?? []).slice(0, 4).map((tag) => (
-          <span key={tag} className="border border-neo-black bg-neo-green px-2 py-1 text-xs font-black uppercase text-neo-black">
+      <div className="flex flex-wrap gap-2">
+        {tool.tags.slice(0, 4).map((tag) => (
+          <span key={tag} className="border border-neo-black bg-neo-white px-2 py-1 text-xs font-black uppercase text-neo-black">
             {tag}
           </span>
         ))}
       </div>
 
-      <div className="mt-4 flex gap-3">
-        {tool.url ? (
-          <a
-            href={tool.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="btn-brutal-primary text-sm"
-          >
-            Open Tool
-          </a>
-        ) : (
-          <div className="border-2 border-dashed border-neo-black px-4 py-3 text-sm font-bold uppercase">
-            URL pending
-          </div>
-        )}
-        {tool.embedUrl && (
-          <span className="border border-neo-black bg-neo-black px-3 py-2 text-xs font-black uppercase text-neo-white">
-            Embeddable
-          </span>
-        )}
+      <div className="mt-auto flex items-center justify-between gap-3 pt-2">
+        <a href={destination} target={destination.startsWith('http') ? '_blank' : undefined} rel="noopener noreferrer" className="btn-brutal-primary text-sm">
+          {tool.ctaLabel}
+        </a>
+        <span className="text-right text-xs font-bold uppercase text-neo-black/60">
+          {tool.audience.slice(0, 2).join(' • ')}
+        </span>
       </div>
     </article>
   );

--- a/components/portal/ToolGrid.tsx
+++ b/components/portal/ToolGrid.tsx
@@ -3,6 +3,7 @@ import { ToolCard } from './ToolCard';
 
 interface ToolGridProps {
   tools: ToolRegistryItem[];
+  title?: string;
   emptyTitle?: string;
   emptyCopy?: string;
   emptyMessage?: string;
@@ -10,6 +11,7 @@ interface ToolGridProps {
 
 export function ToolGrid({
   tools,
+  title,
   emptyTitle = 'No tools loaded yet',
   emptyCopy,
   emptyMessage,
@@ -27,10 +29,18 @@ export function ToolGrid({
   }
 
   return (
-    <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-      {tools.map((tool) => (
-        <ToolCard key={tool.id} tool={tool} />
-      ))}
-    </div>
+    <section className="space-y-4">
+      {title && (
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-black uppercase tracking-tight">{title}</h2>
+          <span className="text-sm font-black uppercase text-neo-black/60">{tools.length} loaded</span>
+        </div>
+      )}
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
+        {tools.map((tool) => (
+          <ToolCard key={tool.id} tool={tool} />
+        ))}
+      </div>
+    </section>
   );
 }

--- a/lib/embed-registry.ts
+++ b/lib/embed-registry.ts
@@ -3,22 +3,57 @@ import path from 'path';
 
 export type ToolAccessLevel = 'public' | 'portal' | 'admin';
 export type ToolStatus = 'draft' | 'active' | 'archived';
+export type RegistryEntryKind = 'tool' | 'resource';
+export type RegistryRenderType = 'iframe' | 'external' | 'internal' | 'download' | 'guide' | 'video' | 'gpt';
+
+export interface BrokerToolAssignment {
+  brokerSlug: string;
+  featured?: boolean;
+  note?: string;
+}
 
 export interface ToolRegistryItem {
   id: string;
   slug: string;
   title: string;
+  description: string;
+  kind: RegistryEntryKind;
   category: string;
-  type: 'link' | 'iframe' | 'embed' | 'app' | 'doc' | 'video';
+  resourceType: string;
+  renderType: RegistryRenderType;
   accessLevel: ToolAccessLevel;
   status: ToolStatus;
   url?: string;
   embedUrl?: string;
-  tags?: string[];
+  icon?: string;
+  ctaLabel: string;
+  ctaHref?: string;
+  tags: string[];
+  audience: string[];
+  verticals: string[];
+  useCases: string[];
+  brokerAssignments: BrokerToolAssignment[];
+  featured: boolean;
+  sortOrder: number;
+  estimatedUseTime?: string;
+  roleFit?: string[];
+  funnelStage?: string;
 }
 
 interface ToolRegistryFile {
   tools: ToolRegistryItem[];
+}
+
+export interface RegistryStats {
+  total: number;
+  active: number;
+  draft: number;
+  archived: number;
+  tools: number;
+  resources: number;
+  embeddable: number;
+  assignedToBrokers: number;
+  missingDestination: number;
 }
 
 async function readRegistryFile(): Promise<ToolRegistryFile> {
@@ -27,27 +62,95 @@ async function readRegistryFile(): Promise<ToolRegistryFile> {
   return JSON.parse(content) as ToolRegistryFile;
 }
 
-export async function getAllTools(): Promise<ToolRegistryItem[]> {
+function bySortThenTitle(a: ToolRegistryItem, b: ToolRegistryItem) {
+  if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+  return a.title.localeCompare(b.title);
+}
+
+function isPubliclyAvailable(item: ToolRegistryItem) {
+  return item.status === 'active';
+}
+
+export async function getAllRegistryItems(): Promise<ToolRegistryItem[]> {
   const registry = await readRegistryFile();
-  return registry.tools ?? [];
+  return (registry.tools ?? []).sort(bySortThenTitle);
+}
+
+export async function getAllTools(): Promise<ToolRegistryItem[]> {
+  return getAllRegistryItems();
 }
 
 export async function getActiveTools(): Promise<ToolRegistryItem[]> {
-  const tools = await getAllTools();
-  return tools.filter((tool) => tool.status === 'active' || tool.status === 'draft');
+  const items = await getAllRegistryItems();
+  return items.filter(isPubliclyAvailable);
 }
 
 export async function getToolsByAccessLevel(accessLevel: ToolAccessLevel): Promise<ToolRegistryItem[]> {
-  const tools = await getAllTools();
-  return tools.filter((tool) => tool.accessLevel === accessLevel || tool.accessLevel === 'public');
+  const items = await getActiveTools();
+  return items.filter((item) => item.accessLevel === accessLevel || item.accessLevel === 'public');
+}
+
+export async function getToolsByKind(kind: RegistryEntryKind): Promise<ToolRegistryItem[]> {
+  const items = await getActiveTools();
+  return items.filter((item) => item.kind === kind);
 }
 
 export async function getToolsByCategory(category: string): Promise<ToolRegistryItem[]> {
-  const tools = await getAllTools();
-  return tools.filter((tool) => tool.category === category);
+  const items = await getActiveTools();
+  return items.filter((item) => item.category === category);
+}
+
+export async function getFeaturedRegistryItems(limit?: number): Promise<ToolRegistryItem[]> {
+  const items = await getActiveTools();
+  const featured = items.filter((item) => item.featured);
+  return typeof limit === 'number' ? featured.slice(0, limit) : featured;
 }
 
 export async function getToolBySlug(slug: string): Promise<ToolRegistryItem | null> {
-  const tools = await getAllTools();
-  return tools.find((tool) => tool.slug === slug) ?? null;
+  const items = await getAllRegistryItems();
+  return items.find((item) => item.slug === slug) ?? null;
+}
+
+export async function getToolsForBroker(brokerSlug: string): Promise<ToolRegistryItem[]> {
+  const items = await getActiveTools();
+  return items
+    .filter((item) => item.brokerAssignments.some((assignment) => assignment.brokerSlug === brokerSlug))
+    .sort((a, b) => {
+      const aAssignment = a.brokerAssignments.find((assignment) => assignment.brokerSlug === brokerSlug);
+      const bAssignment = b.brokerAssignments.find((assignment) => assignment.brokerSlug === brokerSlug);
+      if (Boolean(aAssignment?.featured) !== Boolean(bAssignment?.featured)) {
+        return aAssignment?.featured ? -1 : 1;
+      }
+      return bySortThenTitle(a, b);
+    });
+}
+
+export async function getToolsForVertical(vertical: string): Promise<ToolRegistryItem[]> {
+  const items = await getActiveTools();
+  return items.filter((item) => item.verticals.includes(vertical));
+}
+
+export async function getToolsForAudience(audience: string): Promise<ToolRegistryItem[]> {
+  const items = await getActiveTools();
+  return items.filter((item) => item.audience.includes(audience));
+}
+
+export async function getRegistryStats(): Promise<RegistryStats> {
+  const items = await getAllRegistryItems();
+
+  return {
+    total: items.length,
+    active: items.filter((item) => item.status === 'active').length,
+    draft: items.filter((item) => item.status === 'draft').length,
+    archived: items.filter((item) => item.status === 'archived').length,
+    tools: items.filter((item) => item.kind === 'tool').length,
+    resources: items.filter((item) => item.kind === 'resource').length,
+    embeddable: items.filter((item) => Boolean(item.embedUrl)).length,
+    assignedToBrokers: items.filter((item) => item.brokerAssignments.length > 0).length,
+    missingDestination: items.filter((item) => !item.url && !item.embedUrl && !item.ctaHref).length,
+  };
+}
+
+export function getRegistryDestination(item: ToolRegistryItem) {
+  return item.ctaHref || item.url || item.embedUrl || '#';
 }


### PR DESCRIPTION
## Summary
- Wires broker profile pages to the shared embed registry utility layer.
- Adds a reusable `BrokerUtilitySection` component.
- Uses `getToolsForBroker(broker.slug)` for assigned broker tools.
- Falls back to featured registry tools when a broker has no explicit assignments.
- Keeps the public broker profile useful without hardcoded tool cards.

## Scope
- Public broker profile utility section only.
- No portal/admin route changes.
- No new data model changes.

## Review notes
This is the follow-up slice after PR #46. It consumes the registry work instead of expanding the registry itself.