### PR TITLE
Add registry detail routes

### DIFF
--- a/app/portal/resources/[slug]/page.tsx
+++ b/app/portal/resources/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { getToolBySlug, getToolsByKind } from '@/lib/embed-registry';
+import { RegistryDetailPage } from '@/components/portal/RegistryDetailPage';
+import { notFound } from 'next/navigation';
+
+export const revalidate = 3600;
+
+export async function generateStaticParams() {
+  const resources = await getToolsByKind('resource');
+  return resources.map((resource) => ({ slug: resource.slug }));
+}
+
+export default async function PortalResourceDetailPage({ params }: { params: { slug: string } }) {
+  const item = await getToolBySlug(params.slug);
+
+  if (!item || item.kind !== 'resource') notFound();
+
+  return <RegistryDetailPage item={item} backHref="/portal/resources" backLabel="Back to resources" />;
+}

--- a/app/portal/tools/[slug]/page.tsx
+++ b/app/portal/tools/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { getToolBySlug, getToolsByKind } from '@/lib/embed-registry';
+import { RegistryDetailPage } from '@/components/portal/RegistryDetailPage';
+import { notFound } from 'next/navigation';
+
+export const revalidate = 3600;
+
+export async function generateStaticParams() {
+  const tools = await getToolsByKind('tool');
+  return tools.map((tool) => ({ slug: tool.slug }));
+}
+
+export default async function PortalToolDetailPage({ params }: { params: { slug: string } }) {
+  const item = await getToolBySlug(params.slug);
+
+  if (!item || item.kind !== 'tool') notFound();
+
+  return <RegistryDetailPage item={item} backHref="/portal/tools" backLabel="Back to tools" />;
+}

--- a/components/portal/RegistryDetailPage.tsx
+++ b/components/portal/RegistryDetailPage.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import { getRegistryDestination, type ToolRegistryItem } from '@/lib/embed-registry';
+
+interface RegistryDetailPageProps {
+  item: ToolRegistryItem;
+  backHref: string;
+  backLabel: string;
+}
+
+export function RegistryDetailPage({ item, backHref, backLabel }: RegistryDetailPageProps) {
+  const destination = getRegistryDestination(item);
+
+  return (
+    <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
+      <div className="mx-auto max-w-5xl space-y-8">
+        <Link href={backHref} className="inline-flex border-2 border-neo-black bg-neo-white px-4 py-2 text-sm font-black uppercase tracking-wide shadow-[4px_4px_0_0_rgba(0,0,0,1)]">
+          {backLabel}
+        </Link>
+
+        <section className="border-4 border-neo-black bg-neo-white p-8 shadow-[12px_12px_0_0_rgba(0,0,0,1)]">
+          <div className="flex flex-wrap gap-2 text-xs font-black uppercase">
+            <span className="border border-neo-black bg-neo-yellow px-2 py-1">{item.kind}</span>
+            <span className="border border-neo-black bg-neo-pink px-2 py-1">{item.resourceType}</span>
+            <span className="border border-neo-black bg-neo-green px-2 py-1">{item.renderType}</span>
+          </div>
+          <h1 className="mt-5 text-4xl font-black uppercase tracking-tight md:text-6xl">{item.title}</h1>
+          <p className="mt-4 max-w-3xl text-lg font-medium leading-relaxed text-neo-black/75">{item.description}</p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {item.tags.map((tag) => (
+              <span key={tag} className="border border-neo-black bg-neo-white px-2 py-1 text-xs font-black uppercase">{tag}</span>
+            ))}
+          </div>
+          <a href={destination} target={destination.startsWith('http') ? '_blank' : undefined} rel="noopener noreferrer" className="btn-brutal-primary mt-8 inline-flex">
+            {item.ctaLabel}
+          </a>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-3">
+          <div className="card-brutal bg-neo-white"><p className="text-xs font-black uppercase">Audience</p><p className="mt-2 font-bold">{item.audience.join(', ') || 'General'}</p></div>
+          <div className="card-brutal bg-neo-white"><p className="text-xs font-black uppercase">Verticals</p><p className="mt-2 font-bold">{item.verticals.join(', ') || 'General'}</p></div>
+          <div className="card-brutal bg-neo-white"><p className="text-xs font-black uppercase">Use cases</p><p className="mt-2 font-bold">{item.useCases.join(', ') || 'General'}</p></div>
+        </section>
+
+        {item.embedUrl && (
+          <section className="card-brutal bg-neo-white">
+            <h2 className="text-2xl font-black uppercase">Embeddable surface</h2>
+            <div className="mt-4 aspect-video overflow-hidden border-4 border-neo-black bg-neo-black">
+              <iframe src={item.embedUrl} title={item.title} className="h-full w-full" loading="lazy" />
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/components/portal/ToolCard.tsx
+++ b/components/portal/ToolCard.tsx
@@ -1,11 +1,16 @@
-import { getRegistryDestination, type ToolRegistryItem } from '@/lib/embed-registry';
+import Link from 'next/link';
+import type { ToolRegistryItem } from '@/lib/embed-registry';
 
 interface ToolCardProps {
   tool: ToolRegistryItem;
 }
 
+function getRegistryDetailHref(tool: ToolRegistryItem) {
+  return tool.kind === 'resource' ? `/portal/resources/${tool.slug}` : `/portal/tools/${tool.slug}`;
+}
+
 export function ToolCard({ tool }: ToolCardProps) {
-  const destination = getRegistryDestination(tool);
+  const detailHref = getRegistryDetailHref(tool);
 
   return (
     <article className="card-brutal flex h-full flex-col gap-4 bg-neo-white text-neo-black">
@@ -37,9 +42,9 @@ export function ToolCard({ tool }: ToolCardProps) {
       </div>
 
       <div className="mt-auto flex items-center justify-between gap-3 pt-2">
-        <a href={destination} target={destination.startsWith('http') ? '_blank' : undefined} rel="noopener noreferrer" className="btn-brutal-primary text-sm">
-          {tool.ctaLabel}
-        </a>
+        <Link href={detailHref} className="btn-brutal-primary text-sm">
+          View Details
+        </Link>
         <span className="text-right text-xs font-bold uppercase text-neo-black/60">
           {tool.audience.slice(0, 2).join(' • ')}
         </span>


### PR DESCRIPTION
## Summary
- Adds first-class detail routes for registry-backed tools and resources.
- Introduces a shared `RegistryDetailPage` component.
- Adds `/portal/tools/[slug]` and `/portal/resources/[slug]`.
- Routes registry cards to detail pages instead of generic list surfaces.

## Scope
- Registry detail routes only.
- No new registry schema changes.
- No portal/admin restructuring.

## Review notes
This is the follow-up slice after PR #47. It turns registry cards into real objects with detail views instead of dead-end utility cards.