### PR TITLE
feat: implement v1.1 portal pass with expanded data model, tracking, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install pnpm
+      run: npm install -g pnpm@9
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Check code formatting and linting
+      run: pnpm run lint
+
+    - name: Run tests
+      run: pnpm test
+
+    - name: Build Next.js app
+      run: pnpm run build
+      env:
+        NEXT_TELEMETRY_DISABLED: 1

--- a/__tests__/fetchWixBrokerBySlug.test.ts
+++ b/__tests__/fetchWixBrokerBySlug.test.ts
@@ -17,7 +17,7 @@ describe('fetchWixBrokerBySlug', () => {
     vi.restoreAllMocks();
   });
 
-  it('should return normalized broker from fetch when env vars are present', async () => {
+  it('should return raw broker from fetch when env vars are present', async () => {
     process.env.WIX_API_URL = 'https://api.wix.test';
     process.env.WIX_API_KEY = 'test-key';
 
@@ -55,7 +55,7 @@ describe('fetchWixBrokerBySlug', () => {
       })
     );
     expect(result).not.toBeNull();
-    expect(result?.id).toBe('1');
+    expect(result?._id).toBe('1');
     expect(result?.fullName).toBe('Wix Broker');
   });
 
@@ -74,43 +74,25 @@ describe('fetchWixBrokerBySlug', () => {
     expect(result).toBeNull();
   });
 
-  it('should return mock data when WIX_API_URL or WIX_API_KEY are missing', async () => {
+  it('should throw an error when WIX_API_URL or WIX_API_KEY are missing', async () => {
     delete process.env.WIX_API_URL;
     delete process.env.WIX_API_KEY;
 
-    // Use a known slug from mock data for testing
-    const validMockSlug = mockBrokers.find(b => b.approvalStatus === 'approved' && b.isActive)?.slug || 'test-slug';
-
     const { fetchWixBrokerBySlug } = await import('../lib/wix');
-    const result = await fetchWixBrokerBySlug(validMockSlug);
-
-    expect(global.fetch).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('WIX_API_URL or WIX_API_KEY not found'));
-
-    const expectedMockData = mockBrokers.find(b => b.slug === validMockSlug && b.approvalStatus === 'approved' && b.isActive) || null;
-    expect(result).toEqual(expectedMockData);
+    await expect(fetchWixBrokerBySlug('test-slug')).rejects.toThrow('WIX_API_URL or WIX_API_KEY not found');
   });
 
-  it('should fallback to mock data when fetch fails (network error)', async () => {
+  it('should throw when fetch fails (network error)', async () => {
     process.env.WIX_API_URL = 'https://api.wix.test';
     process.env.WIX_API_KEY = 'test-key';
 
     vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
 
-    // Use a known slug from mock data for testing
-    const validMockSlug = mockBrokers.find(b => b.approvalStatus === 'approved' && b.isActive)?.slug || 'test-slug';
-
     const { fetchWixBrokerBySlug } = await import('../lib/wix');
-    const result = await fetchWixBrokerBySlug(validMockSlug);
-
-    expect(global.fetch).toHaveBeenCalled();
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error fetching Wix broker with slug'), expect.any(Error));
-
-    const expectedMockData = mockBrokers.find(b => b.slug === validMockSlug && b.approvalStatus === 'approved' && b.isActive) || null;
-    expect(result).toEqual(expectedMockData);
+    await expect(fetchWixBrokerBySlug('test-slug')).rejects.toThrow('Network error');
   });
 
-  it('should fallback to mock data when response is not ok', async () => {
+  it('should throw when response is not ok', async () => {
     process.env.WIX_API_URL = 'https://api.wix.test';
     process.env.WIX_API_KEY = 'test-key';
 
@@ -119,26 +101,9 @@ describe('fetchWixBrokerBySlug', () => {
       statusText: 'Internal Server Error'
     } as Response);
 
-    // Use a known slug from mock data for testing
-    const validMockSlug = mockBrokers.find(b => b.approvalStatus === 'approved' && b.isActive)?.slug || 'test-slug';
-
     const { fetchWixBrokerBySlug } = await import('../lib/wix');
-    const result = await fetchWixBrokerBySlug(validMockSlug);
-
-    expect(global.fetch).toHaveBeenCalled();
-    expect(console.error).toHaveBeenCalled();
-
-    const expectedMockData = mockBrokers.find(b => b.slug === validMockSlug && b.approvalStatus === 'approved' && b.isActive) || null;
-    expect(result).toEqual(expectedMockData);
+    await expect(fetchWixBrokerBySlug('test-slug')).rejects.toThrow('Failed to fetch from Wix: Internal Server Error');
   });
 
-  it('should return null when falling back to mock data and slug is not found', async () => {
-    delete process.env.WIX_API_URL;
-    delete process.env.WIX_API_KEY;
 
-    const { fetchWixBrokerBySlug } = await import('../lib/wix');
-    const result = await fetchWixBrokerBySlug('definitely-not-a-real-slug-12345');
-
-    expect(result).toBeNull();
-  });
 });

--- a/__tests__/fetchWixBrokers.test.ts
+++ b/__tests__/fetchWixBrokers.test.ts
@@ -17,7 +17,7 @@ describe('fetchWixBrokers', () => {
     vi.restoreAllMocks();
   });
 
-  it('should return normalized brokers from fetch when env vars are present', async () => {
+  it('should return raw brokers from fetch when env vars are present', async () => {
     process.env.WIX_API_URL = 'https://api.wix.test';
     process.env.WIX_API_KEY = 'test-key';
 
@@ -55,42 +55,31 @@ describe('fetchWixBrokers', () => {
       })
     );
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('1');
+    expect(result[0]._id).toBe('1');
     expect(result[0].fullName).toBe('Wix Broker');
-    expect(result[0].primaryCta.label).toBe('Apply Now');
+
   });
 
-  it('should return mock data when WIX_API_URL or WIX_API_KEY are missing', async () => {
+  it('should throw an error when WIX_API_URL or WIX_API_KEY are missing', async () => {
     delete process.env.WIX_API_URL;
     delete process.env.WIX_API_KEY;
 
     const { fetchWixBrokers } = await import('../lib/wix');
-    const result = await fetchWixBrokers();
-
+    await expect(fetchWixBrokers()).rejects.toThrow('WIX_API_URL or WIX_API_KEY not found');
     expect(global.fetch).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('WIX_API_URL or WIX_API_KEY not found'));
-
-    const expectedMockData = mockBrokers.filter(b => b.approvalStatus === 'approved' && b.isActive);
-    expect(result).toEqual(expectedMockData);
   });
 
-  it('should fallback to mock data when fetch fails (network error)', async () => {
+  it('should throw when fetch fails (network error)', async () => {
     process.env.WIX_API_URL = 'https://api.wix.test';
     process.env.WIX_API_KEY = 'test-key';
 
     vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
 
     const { fetchWixBrokers } = await import('../lib/wix');
-    const result = await fetchWixBrokers();
-
-    expect(global.fetch).toHaveBeenCalled();
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error fetching Wix brokers'), expect.any(Error));
-
-    const expectedMockData = mockBrokers.filter(b => b.approvalStatus === 'approved' && b.isActive);
-    expect(result).toEqual(expectedMockData);
+    await expect(fetchWixBrokers()).rejects.toThrow('Network error');
   });
 
-  it('should fallback to mock data when response is not ok', async () => {
+  it('should throw when response is not ok', async () => {
     process.env.WIX_API_URL = 'https://api.wix.test';
     process.env.WIX_API_KEY = 'test-key';
 
@@ -100,13 +89,7 @@ describe('fetchWixBrokers', () => {
     } as Response);
 
     const { fetchWixBrokers } = await import('../lib/wix');
-    const result = await fetchWixBrokers();
-
-    expect(global.fetch).toHaveBeenCalled();
-    expect(console.error).toHaveBeenCalled();
-
-    const expectedMockData = mockBrokers.filter(b => b.approvalStatus === 'approved' && b.isActive);
-    expect(result).toEqual(expectedMockData);
+    await expect(fetchWixBrokers()).rejects.toThrow('Failed to fetch from Wix: Internal Server Error');
   });
 
   it('should return an empty array if fetch returns empty array', async () => {

--- a/__tests__/getBrokerBySlug.test.ts
+++ b/__tests__/getBrokerBySlug.test.ts
@@ -9,13 +9,14 @@ vi.mock('../lib/wix', () => ({
 
 describe('getBrokerBySlug', () => {
   it('should return a broker when a matching slug is found', async () => {
-    const mockBroker = { id: '1', fullName: 'Broker One', slug: 'broker-one', isActive: true, approvalStatus: 'approved' };
+    const mockBroker = { _id: '1', fullName: 'Broker One', slug: 'broker-one', isActive: true, approvalStatus: 'approved' };
     vi.mocked(wix.fetchWixBrokerBySlug).mockResolvedValue(mockBroker as any);
 
     const result = await getBrokerBySlug('broker-one');
 
     expect(wix.fetchWixBrokerBySlug).toHaveBeenCalledWith('broker-one');
-    expect(result).toEqual(mockBroker);
+    expect(result?.id).toBe('1');
+    expect(result?.fullName).toBe('Broker One');
   });
 
   it('should return null when no matching broker is found', async () => {
@@ -36,9 +37,12 @@ describe('getBrokerBySlug', () => {
     expect(result).toBeNull();
   });
 
-  it('should propagate errors from fetchWixBrokerBySlug', async () => {
+  it('should fallback to mock data when fetchWixBrokerBySlug throws', async () => {
     vi.mocked(wix.fetchWixBrokerBySlug).mockRejectedValue(new Error('Fetch failed'));
 
-    await expect(getBrokerBySlug('broker-one')).rejects.toThrow('Fetch failed');
+    const mockBrokers = await import('../lib/mock-brokers').then(m => m.mockBrokers);
+    const expected = mockBrokers.find(b => b.slug === 'jane-doe' && b.approvalStatus === 'approved' && b.isActive) || null;
+    const result = await getBrokerBySlug('jane-doe');
+    expect(result).toEqual(expected);
   });
 });

--- a/__tests__/getBrokers.test.ts
+++ b/__tests__/getBrokers.test.ts
@@ -10,15 +10,17 @@ vi.mock('../lib/wix', () => ({
 describe('getBrokers', () => {
   it('should return a list of brokers on happy path', async () => {
     const mockBrokers = [
-      { id: '1', fullName: 'Broker One', slug: 'broker-one', isActive: true, approvalStatus: 'approved' },
-      { id: '2', fullName: 'Broker Two', slug: 'broker-two', isActive: true, approvalStatus: 'approved' },
+      { _id: '1', fullName: 'Broker One', slug: 'broker-one', isActive: true, approvalStatus: 'approved' },
+      { _id: '2', fullName: 'Broker Two', slug: 'broker-two', isActive: true, approvalStatus: 'approved' },
     ];
     vi.mocked(wix.fetchWixBrokers).mockResolvedValue(mockBrokers as any);
 
     const result = await getBrokers();
 
     expect(wix.fetchWixBrokers).toHaveBeenCalled();
-    expect(result).toEqual(mockBrokers);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('1');
+    expect(result[1].id).toBe('2');
   });
 
   it('should return an empty array if no brokers are returned', async () => {
@@ -30,9 +32,13 @@ describe('getBrokers', () => {
     expect(result).toEqual([]);
   });
 
-  it('should propagate errors from fetchWixBrokers', async () => {
+  it('should fallback to mock data when fetchWixBrokers throws', async () => {
     vi.mocked(wix.fetchWixBrokers).mockRejectedValue(new Error('Fetch failed'));
 
-    await expect(getBrokers()).rejects.toThrow('Fetch failed');
+    const mockBrokers = await import('../lib/mock-brokers').then(m => m.mockBrokers);
+    const expected = mockBrokers.filter(b => b.approvalStatus === 'approved' && b.isActive);
+
+    const result = await getBrokers();
+    expect(result).toEqual(expected);
   });
 });

--- a/__tests__/getFeaturedBrokers.test.ts
+++ b/__tests__/getFeaturedBrokers.test.ts
@@ -9,9 +9,9 @@ vi.mock('../lib/wix', () => ({
 describe('getFeaturedBrokers', () => {
   it('should return only featured brokers', async () => {
     const mockBrokers = [
-      { id: '1', fullName: 'Broker One', featuredFlag: true, isActive: true, approvalStatus: 'approved' },
-      { id: '2', fullName: 'Broker Two', featuredBroker: true, isActive: true, approvalStatus: 'approved' },
-      { id: '3', fullName: 'Broker Three', isActive: true, approvalStatus: 'approved' },
+      { _id: '1', fullName: 'Broker One', featuredFlag: true, isActive: true, approvalStatus: 'approved' },
+      { _id: '2', fullName: 'Broker Two', featuredBroker: true, isActive: true, approvalStatus: 'approved' },
+      { _id: '3', fullName: 'Broker Three', isActive: true, approvalStatus: 'approved' },
       { id: '4', fullName: 'Broker Four', featuredFlag: false, featuredBroker: false, isActive: true, approvalStatus: 'approved' },
     ];
     vi.mocked(wix.fetchWixBrokers).mockResolvedValue(mockBrokers as any);
@@ -24,8 +24,8 @@ describe('getFeaturedBrokers', () => {
 
   it('should return an empty array if there are no featured brokers', async () => {
     const mockBrokers = [
-      { id: '1', fullName: 'Broker One', isActive: true },
-      { id: '2', fullName: 'Broker Two', isActive: true },
+      { _id: '1', fullName: 'Broker One', isActive: true },
+      { _id: '2', fullName: 'Broker Two', isActive: true },
     ];
     vi.mocked(wix.fetchWixBrokers).mockResolvedValue(mockBrokers as any);
 
@@ -42,9 +42,13 @@ describe('getFeaturedBrokers', () => {
     expect(result).toEqual([]);
   });
 
-  it('should propagate errors from fetchWixBrokers', async () => {
+  it('should fallback to mock data when fetchWixBrokers throws', async () => {
     vi.mocked(wix.fetchWixBrokers).mockRejectedValue(new Error('Fetch failed'));
 
-    await expect(getFeaturedBrokers()).rejects.toThrow('Fetch failed');
+    const mockBrokers = await import('../lib/mock-brokers').then(m => m.mockBrokers);
+    const expected = mockBrokers.filter(b => b.approvalStatus === 'approved' && b.isActive && (b.featuredFlag || b.featuredBroker));
+
+    const result = await getFeaturedBrokers();
+    expect(result).toEqual(expected);
   });
 });

--- a/app/directory/[slug]/page.tsx
+++ b/app/directory/[slug]/page.tsx
@@ -83,6 +83,29 @@ export default async function BrokerProfilePage({ params }: { params: { slug: st
               <p className="text-xl font-bold border-l-4 border-neo-black pl-6">{broker.shortBio}</p>
             </section>
 
+            {broker.bestFitClients && (
+              <section>
+                <SectionHeading title="Best Fit Clients" color="pink" />
+                <div className="bg-neo-black text-neo-white p-8 border-4 border-neo-pink shadow-brutal text-lg font-medium leading-relaxed">
+                  {broker.bestFitClients}
+                </div>
+              </section>
+            )}
+
+            {broker.proofPoints && broker.proofPoints.length > 0 && (
+              <section>
+                <SectionHeading title="Proof Points" color="green" />
+                <ul className="space-y-4">
+                  {broker.proofPoints.map((point, i) => (
+                    <li key={i} className="flex items-start gap-4 font-bold text-lg bg-neo-white p-4 border-2 border-neo-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+                      <span className="flex-shrink-0 w-6 h-6 bg-neo-green border border-neo-black mt-1"></span>
+                      {point}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
             <BrokerUtilitySection
               brokerName={broker.fullName}
               tools={brokerTools.length > 0 ? brokerTools : fallbackTools}
@@ -117,6 +140,14 @@ export default async function BrokerProfilePage({ params }: { params: { slug: st
                 {broker.publicEmail && <div><div className="text-sm uppercase text-neo-black/60 mb-1">Email</div><a href={`mailto:${broker.publicEmail}`} className="text-neo-blue hover:underline break-all">{broker.publicEmail}</a></div>}
                 {broker.phoneNumber && <div><div className="text-sm uppercase text-neo-black/60 mb-1">Phone</div><a href={`tel:${broker.phoneNumber}`} className="hover:underline">{broker.phoneNumber}</a></div>}
               </div>
+            </div>
+
+            <div className="bg-neo-yellow p-8 border-4 border-neo-black shadow-brutal text-center">
+              <h3 className="font-black text-2xl uppercase tracking-tighter mb-4">Not the right fit?</h3>
+              <p className="font-medium text-lg mb-6">We can match you with the perfect capital partner for your specific deal size and industry.</p>
+              <Link href={process.env.NEXT_PUBLIC_MATCH_URL || "/onboarding"} className="btn-brutal w-full bg-neo-black text-neo-white border-2 border-neo-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all inline-block">
+                Get Matched
+              </Link>
             </div>
           </div>
         </div>

--- a/app/out/route.ts
+++ b/app/out/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getBrokerBySlug } from '@/lib/brokers';
 import { sanitizeUrl } from '@/lib/utils';
+import { trackBrokerCtaClick } from '@/lib/tracking';
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
@@ -32,8 +33,7 @@ export async function GET(request: NextRequest) {
     destinationUrl = `/directory/${brokerSlug}`;
   }
 
-  // Log event (MVP)
-  console.log('[Tracking Event]', {
+  const payload = {
     event: 'cta_click',
     broker: brokerSlug,
     type,
@@ -42,7 +42,13 @@ export async function GET(request: NextRequest) {
     timestamp: new Date().toISOString(),
     userAgent: request.headers.get('user-agent') || 'unknown',
     referrer: request.headers.get('referer') || 'unknown',
-  });
+  };
+
+  // Log event (MVP)
+  console.log('[Tracking Event]', payload);
+
+  // Send to tracking webhook asynchronously without blocking response
+  void trackBrokerCtaClick(payload);
 
   return NextResponse.redirect(new URL(destinationUrl, request.url));
 }

--- a/components/CTASection.tsx
+++ b/components/CTASection.tsx
@@ -13,9 +13,14 @@ export function CTASection() {
         <p className="text-xl md:text-2xl font-black mb-12">
           Connect with an operator who understands your business and gets deals funded.
         </p>
-        <Link href="/directory" className="btn-brutal bg-neo-black text-neo-white text-xl px-12 py-6 border-4 border-neo-black shadow-[6px_6px_0px_0px_rgba(244,244,240,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all">
-          Find a Partner Now
-        </Link>
+        <div className="flex flex-col sm:flex-row justify-center gap-6">
+          <Link href="/directory" className="btn-brutal bg-neo-black text-neo-white text-xl px-12 py-6 border-4 border-neo-black shadow-[6px_6px_0px_0px_rgba(244,244,240,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all">
+            Browse Directory
+          </Link>
+          <Link href={process.env.NEXT_PUBLIC_MATCH_URL || "/onboarding"} className="btn-brutal bg-neo-yellow text-neo-black text-xl px-12 py-6 border-4 border-neo-black shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all">
+            Get Matched
+          </Link>
+        </div>
       </div>
     </section>
   );

--- a/components/DirectoryClient.tsx
+++ b/components/DirectoryClient.tsx
@@ -18,7 +18,7 @@ export function DirectoryClient({ initialBrokers }: DirectoryClientProps) {
 
   // Compute unique filter options
   const availableStates = useMemo(() =>
-    Array.from(new Set(initialBrokers.map(b => b.state).filter(Boolean))).sort(),
+    Array.from(new Set(initialBrokers.flatMap(b => [b.state, ...(b.serviceArea || [])]).filter(Boolean))).sort(),
   [initialBrokers]);
 
   const availableSpecialties = useMemo(() =>
@@ -26,7 +26,7 @@ export function DirectoryClient({ initialBrokers }: DirectoryClientProps) {
   [initialBrokers]);
 
   const availableIndustries = useMemo(() =>
-    Array.from(new Set(initialBrokers.flatMap(b => b.industries || []))).sort(),
+    Array.from(new Set(initialBrokers.flatMap(b => b.verticals || b.industries || []))).sort(),
   [initialBrokers]);
 
   // Filter brokers
@@ -37,15 +37,15 @@ export function DirectoryClient({ initialBrokers }: DirectoryClientProps) {
         broker.fullName.toLowerCase().includes(lowerSearchTerm) ||
         broker.agencyName.toLowerCase().includes(lowerSearchTerm);
 
-      const matchesState = selectedState === '' || broker.state === selectedState;
+      const matchesState = selectedState === '' || broker.state === selectedState || (broker.serviceArea && broker.serviceArea.includes(selectedState));
 
       const typesToSearch = broker.fundingTypes || broker.fundingSpecialties || [];
       const matchesSpecialty = selectedSpecialty === '' || typesToSearch.includes(selectedSpecialty);
 
-      const industriesToSearch = broker.industries || [];
+      const industriesToSearch = broker.verticals || broker.industries || [];
       const matchesIndustry = selectedIndustry === '' || industriesToSearch.includes(selectedIndustry);
 
-      const matchesUrgency = selectedUrgency === '' || broker.urgencyCategory === selectedUrgency;
+      const matchesUrgency = selectedUrgency === '' || broker.urgencyCategory === selectedUrgency || broker.speedToContact === selectedUrgency;
 
       return matchesSearch && matchesState && matchesSpecialty && matchesIndustry && matchesUrgency;
     });

--- a/components/DirectoryFilters.tsx
+++ b/components/DirectoryFilters.tsx
@@ -47,14 +47,14 @@ export function DirectoryFilters({
         </div>
 
         <div className="w-full md:w-48">
-          <label htmlFor="state" className="block font-bold uppercase text-sm mb-2 text-neo-black">State</label>
+          <label htmlFor="state" className="block font-bold uppercase text-sm mb-2 text-neo-black">State / Service Area</label>
           <select
             id="state"
             value={selectedState}
             onChange={(e) => setSelectedState(e.target.value)}
             className="w-full p-3 border-2 border-neo-black bg-neo-white font-bold focus:outline-none focus:ring-2 focus:ring-neo-blue shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] appearance-none rounded-none"
           >
-            <option value="">All States</option>
+            <option value="">All Areas</option>
             {availableStates.map(s => <option key={s} value={s}>{s}</option>)}
           </select>
         </div>
@@ -88,7 +88,7 @@ export function DirectoryFilters({
         </div>
 
         <div className="w-full md:flex-1">
-          <label htmlFor="urgency" className="block font-bold uppercase text-sm mb-2 text-neo-black">Urgency</label>
+          <label htmlFor="urgency" className="block font-bold uppercase text-sm mb-2 text-neo-black">Urgency / Speed</label>
           <select
             id="urgency"
             value={selectedUrgency}

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -19,6 +19,9 @@ export function HeroSection() {
           <Link href="/directory" className="btn-brutal-primary text-lg px-8 py-4">
             Browse Directory
           </Link>
+          <Link href={process.env.NEXT_PUBLIC_MATCH_URL || "/onboarding"} className="btn-brutal-primary bg-neo-yellow text-neo-black border-neo-black text-lg px-8 py-4">
+            Get Matched
+          </Link>
           <Link href="/onboarding" className="btn-brutal text-lg px-8 py-4">
             Become a Partner
           </Link>

--- a/lib/brokers.ts
+++ b/lib/brokers.ts
@@ -1,20 +1,81 @@
 import { BrokerProfile } from './types';
-import { fetchWixBrokers, fetchWixBrokerBySlug } from './wix';
+import { fetchWixBrokers, fetchWixBrokerBySlug, WixBrokerResponse } from './wix';
 import { isEligibleForPublicDisplay } from './status-gating';
+import { mockBrokers } from './mock-brokers';
+
+export function normalizeBroker(wixBroker: WixBrokerResponse): BrokerProfile {
+  return {
+    id: wixBroker._id,
+    fullName: wixBroker.fullName,
+    agencyName: wixBroker.agencyName,
+    slug: wixBroker.slug,
+    shortBio: wixBroker.shortBio,
+    city: wixBroker.city,
+    state: wixBroker.state,
+    websiteUrl: wixBroker.websiteUrl,
+    publicEmail: wixBroker.publicEmail,
+    whyChooseYou: wixBroker.whyChooseYou,
+
+    industries: wixBroker.industries || [],
+    verticals: wixBroker.verticals || wixBroker.industries || [],
+    fundingTypes: wixBroker.fundingTypes || wixBroker.fundingSpecialties || [],
+    urgencyCategory: wixBroker.urgencyCategory || 'standard',
+    serviceArea: wixBroker.serviceArea || [],
+    speedToContact: wixBroker.speedToContact,
+    minimumDealSize: wixBroker.minimumDealSize,
+    maximumDealSize: wixBroker.maximumDealSize,
+    primaryCtaType: wixBroker.primaryCtaType || 'apply',
+    proofPoints: wixBroker.proofPoints || [],
+    bestFitClients: wixBroker.bestFitClients,
+
+    fundingSpecialties: wixBroker.fundingSpecialties || [],
+    primaryCtaLink: wixBroker.primaryCtaLink,
+    ctaLabel: wixBroker.ctaLabel,
+    featuredBroker: wixBroker.featuredBroker,
+    featuredFlag: wixBroker.featuredFlag || wixBroker.featuredBroker,
+
+    primaryCta: {
+      label: wixBroker.ctaLabel || 'Apply Now',
+      url: wixBroker.primaryCtaLink || '#',
+      variant: 'primary',
+      trackingId: `broker_cta_${wixBroker._id}`
+    },
+
+    profileImage: wixBroker.profileImage,
+    approvalStatus: wixBroker.approvalStatus,
+    brokerStatus: wixBroker.brokerStatus || 'active',
+    isActive: wixBroker.isActive !== undefined ? wixBroker.isActive : true,
+    phoneNumber: wixBroker.phoneNumber,
+  };
+}
 
 export async function getBrokers(): Promise<BrokerProfile[]> {
-  const brokers = await fetchWixBrokers();
-  // Ensure we only return brokers eligible for public display
-  return brokers.filter(isEligibleForPublicDisplay);
+  try {
+    const rawBrokers = await fetchWixBrokers();
+    const brokers = rawBrokers.map(normalizeBroker);
+    return brokers.filter(isEligibleForPublicDisplay);
+  } catch (error) {
+    console.warn('Wix fetch failed, falling back to mockBrokers:', error);
+    return mockBrokers.filter(b => b.approvalStatus === 'approved' && b.isActive);
+  }
 }
 
 export async function getBrokerBySlug(slug: string): Promise<BrokerProfile | null> {
-  const broker = await fetchWixBrokerBySlug(slug);
-  // Ensure the requested broker is eligible for public display
-  if (broker && !isEligibleForPublicDisplay(broker)) {
-    return null;
+  try {
+    const rawBroker = await fetchWixBrokerBySlug(slug);
+    if (!rawBroker) {
+        return null;
+    }
+    const broker = normalizeBroker(rawBroker);
+    if (!isEligibleForPublicDisplay(broker)) {
+      return null;
+    }
+    return broker;
+  } catch (error) {
+    console.warn(`Wix fetch failed for slug ${slug}, falling back to mockBrokers:`, error);
+    const broker = mockBrokers.find(b => b.slug === slug && b.approvalStatus === 'approved' && b.isActive);
+    return broker || null;
   }
-  return broker;
 }
 
 export async function getFeaturedBrokers(): Promise<BrokerProfile[]> {

--- a/lib/mock-brokers.ts
+++ b/lib/mock-brokers.ts
@@ -17,6 +17,14 @@ export const mockBrokers: BrokerProfile[] = [
     industries: ['Construction', 'Transportation', 'Service Businesses', 'Real Estate'],
     fundingTypes: ['Equipment Financing', 'Vehicle & Fleet Financing', 'Revenue-Based Funding', 'Business Term Loans', 'SBA Options'],
     urgencyCategory: 'standard',
+    serviceArea: ['Nationwide'],
+    speedToContact: 'Within 2 hours',
+    minimumDealSize: 50000,
+    maximumDealSize: 5000000,
+    primaryCtaType: 'apply',
+    proofPoints: ['Over $50M deployed', 'Fast approval process', 'Transparent terms'],
+    bestFitClients: 'Established businesses with minimum $500k annual revenue looking for equipment upgrades or expansion capital.',
+    verticals: ['Construction', 'Transportation', 'Service Businesses', 'Real Estate'],
     fundingSpecialties: ['Equipment Financing', 'Vehicle & Fleet Financing', 'Revenue-Based Funding', 'Business Term Loans', 'SBA Options'],
 
     primaryCta: {
@@ -56,6 +64,14 @@ export const mockBrokers: BrokerProfile[] = [
     industries: ['SaaS', 'Manufacturing', 'Technology'],
     fundingTypes: ['SaaS Revenue', 'Equipment Finance', 'Bridge Loans'],
     urgencyCategory: 'fast',
+    serviceArea: ['TX', 'CA', 'NY', 'FL'],
+    speedToContact: 'Within 1 hour',
+    minimumDealSize: 100000,
+    maximumDealSize: 10000000,
+    primaryCtaType: 'apply',
+    proofPoints: ['Specialized in SaaS metrics', 'Non-dilutive capital', 'Founder-friendly terms'],
+    bestFitClients: 'SaaS and tech companies with $1M+ ARR looking to extend runway without giving up equity.',
+    verticals: ['SaaS', 'Manufacturing', 'Technology'],
     fundingSpecialties: ['SaaS Revenue', 'Equipment Finance', 'Bridge Loans'],
 
     primaryCta: {
@@ -87,6 +103,14 @@ export const mockBrokers: BrokerProfile[] = [
     industries: ['Construction', 'Real Estate', 'Logistics'],
     fundingTypes: ['Equipment Finance', 'Real Estate', 'SBA Loans'],
     urgencyCategory: 'standard',
+    serviceArea: ['Midwest USA', 'IL', 'OH', 'MI'],
+    speedToContact: 'Same business day',
+    minimumDealSize: 250000,
+    maximumDealSize: 15000000,
+    primaryCtaType: 'apply',
+    proofPoints: ['Deep real estate expertise', 'Flexible collateral requirements', 'Quick closing times'],
+    bestFitClients: 'Real estate developers and construction firms needing quick access to bridge capital or equipment financing.',
+    verticals: ['Construction', 'Real Estate', 'Logistics'],
     fundingSpecialties: ['Equipment Finance', 'Real Estate', 'SBA Loans'],
 
     primaryCta: {
@@ -118,6 +142,14 @@ export const mockBrokers: BrokerProfile[] = [
     industries: ['E-commerce', 'Retail', 'DTC'],
     fundingTypes: ['Revenue Based', 'Working Capital'],
     urgencyCategory: 'fast',
+    serviceArea: ['Global'],
+    speedToContact: 'Within 30 minutes',
+    minimumDealSize: 10000,
+    maximumDealSize: 2000000,
+    primaryCtaType: 'apply',
+    proofPoints: ['Data-driven underwriting', 'Connect store directly', 'Capital in 24 hours'],
+    bestFitClients: 'E-commerce brands needing inventory or ad spend capital ahead of peak seasons.',
+    verticals: ['E-commerce', 'Retail', 'DTC'],
     fundingSpecialties: ['E-commerce', 'Revenue Based', 'Working Capital'],
 
     primaryCta: {
@@ -149,6 +181,14 @@ export const mockBrokers: BrokerProfile[] = [
     industries: ['Healthcare', 'B2B Services', 'Enterprise'],
     fundingTypes: ['M&A', 'Bridge Loans', 'Term Loans'],
     urgencyCategory: 'complex',
+    serviceArea: ['North America'],
+    speedToContact: 'Next business day',
+    minimumDealSize: 1000000,
+    maximumDealSize: 50000000,
+    primaryCtaType: 'book_call',
+    proofPoints: ['Complex structuring capabilities', 'Network of institutional partners', 'End-to-end M&A advisory'],
+    bestFitClients: 'Mid-market companies ($10M - $100M revenue) seeking acquisition financing or undergoing major recapitalization.',
+    verticals: ['Healthcare', 'B2B Services', 'Enterprise'],
     fundingSpecialties: ['M&A', 'Bridge Loans', 'Term Loans'],
 
     primaryCta: {

--- a/lib/tracking.ts
+++ b/lib/tracking.ts
@@ -1,0 +1,24 @@
+export async function trackBrokerCtaClick(payload: any) {
+  const webhookUrl = process.env.N8N_CTA_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    console.warn('[Tracking] N8N_CTA_WEBHOOK_URL not set. Skipping trackBrokerCtaClick.', payload);
+    return;
+  }
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      console.warn(`[Tracking] Webhook failed with status: ${res.status}`);
+    }
+  } catch (err) {
+    console.error('[Tracking] Failed to track CTA click:', err);
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,8 +21,16 @@ export interface BrokerProfile {
 
   // Expanded Data Model
   industries: string[];
+  verticals?: string[];
   fundingTypes: string[];
   urgencyCategory: 'fast' | 'standard' | 'complex' | string;
+  serviceArea?: string[];
+  speedToContact?: string;
+  minimumDealSize?: number;
+  maximumDealSize?: number;
+  primaryCtaType?: string;
+  proofPoints?: string[];
+  bestFitClients?: string;
 
   // Legacy / Fallback properties
   fundingSpecialties?: string[];

--- a/lib/wix.ts
+++ b/lib/wix.ts
@@ -1,8 +1,6 @@
-import { BrokerProfile } from './types';
 import { mockBrokers } from './mock-brokers';
 
-// Define expected Wix response structure
-interface WixBrokerResponse {
+export interface WixBrokerResponse {
   _id: string;
   fullName: string;
   agencyName: string;
@@ -14,8 +12,16 @@ interface WixBrokerResponse {
   publicEmail: string;
   whyChooseYou: string;
   industries?: string[];
+  verticals?: string[];
   fundingTypes?: string[];
   urgencyCategory?: string;
+  serviceArea?: string[];
+  speedToContact?: string;
+  minimumDealSize?: number;
+  maximumDealSize?: number;
+  primaryCtaType?: string;
+  proofPoints?: string[];
+  bestFitClients?: string;
   fundingSpecialties?: string[];
   primaryCtaLink?: string;
   ctaLabel?: string;
@@ -26,112 +32,53 @@ interface WixBrokerResponse {
   brokerStatus?: 'active' | 'hidden' | 'recruiting';
   isActive: boolean;
   phoneNumber?: string;
-  // Raw Wix CTA fields if any, we'll map them
 }
 
 const WIX_API_URL = process.env.WIX_API_URL || '';
 const WIX_API_KEY = process.env.WIX_API_KEY || '';
 
-// Normalization function to ensure Wix data matches our frontend types
-function normalizeBroker(wixBroker: WixBrokerResponse): BrokerProfile {
-  return {
-    id: wixBroker._id,
-    fullName: wixBroker.fullName,
-    agencyName: wixBroker.agencyName,
-    slug: wixBroker.slug,
-    shortBio: wixBroker.shortBio,
-    city: wixBroker.city,
-    state: wixBroker.state,
-    websiteUrl: wixBroker.websiteUrl,
-    publicEmail: wixBroker.publicEmail,
-    whyChooseYou: wixBroker.whyChooseYou,
+export async function fetchWixBrokers(): Promise<WixBrokerResponse[]> {
+  if (!WIX_API_URL || !WIX_API_KEY) {
+    throw new Error('WIX_API_URL or WIX_API_KEY not found');
+  }
 
-    industries: wixBroker.industries || [],
-    fundingTypes: wixBroker.fundingTypes || wixBroker.fundingSpecialties || [],
-    urgencyCategory: wixBroker.urgencyCategory || 'standard',
-
-    fundingSpecialties: wixBroker.fundingSpecialties || [],
-    primaryCtaLink: wixBroker.primaryCtaLink,
-    ctaLabel: wixBroker.ctaLabel,
-    featuredBroker: wixBroker.featuredBroker,
-    featuredFlag: wixBroker.featuredFlag || wixBroker.featuredBroker,
-
-    primaryCta: {
-      label: wixBroker.ctaLabel || 'Apply Now',
-      url: wixBroker.primaryCtaLink || '#',
-      variant: 'primary',
-      trackingId: `broker_cta_${wixBroker._id}`
+  const res = await fetch(`${WIX_API_URL}/brokerProfiles?status=approved&active=true`, {
+    headers: {
+      'Authorization': `Bearer ${WIX_API_KEY}`,
+      'Content-Type': 'application/json'
     },
+    next: { revalidate: 3600 }
+  });
 
-    profileImage: wixBroker.profileImage,
-    approvalStatus: wixBroker.approvalStatus,
-    brokerStatus: wixBroker.brokerStatus || 'active',
-    isActive: wixBroker.isActive !== undefined ? wixBroker.isActive : true,
-    phoneNumber: wixBroker.phoneNumber,
-  };
+  if (!res.ok) {
+    throw new Error(`Failed to fetch from Wix: ${res.statusText}`);
+  }
+
+  const data: WixBrokerResponse[] = await res.json();
+  return data;
 }
 
-export async function fetchWixBrokers(): Promise<BrokerProfile[]> {
-  // If no API credentials, fallback to mock data
+export async function fetchWixBrokerBySlug(slug: string): Promise<WixBrokerResponse | null> {
   if (!WIX_API_URL || !WIX_API_KEY) {
-    console.warn('WIX_API_URL or WIX_API_KEY not found. Falling back to mock data.');
-    await new Promise(resolve => setTimeout(resolve, 500));
-    return mockBrokers.filter(b => b.approvalStatus === 'approved' && b.isActive);
+    throw new Error('WIX_API_URL or WIX_API_KEY not found');
   }
 
-  try {
-    const res = await fetch(`${WIX_API_URL}/brokerProfiles?status=approved&active=true`, {
-      headers: {
-        'Authorization': `Bearer ${WIX_API_KEY}`,
-        'Content-Type': 'application/json'
-      },
-      next: { revalidate: 3600 } // ISR for 1 hour
-    });
+  const encodedSlug = encodeURIComponent(slug);
+  const res = await fetch(`${WIX_API_URL}/brokerProfiles?slug=${encodedSlug}&status=approved&active=true`, {
+    headers: {
+      'Authorization': `Bearer ${WIX_API_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    next: { revalidate: 3600 }
+  });
 
-    if (!res.ok) {
-      throw new Error(`Failed to fetch from Wix: ${res.statusText}`);
-    }
-
-    const data: WixBrokerResponse[] = await res.json();
-    return data.map(normalizeBroker);
-  } catch (error) {
-    console.error('Error fetching Wix brokers:', error);
-    // Fallback to mock data if fetch fails
-    return mockBrokers.filter(b => b.approvalStatus === 'approved' && b.isActive);
-  }
-}
-
-export async function fetchWixBrokerBySlug(slug: string): Promise<BrokerProfile | null> {
-  // If no API credentials, fallback to mock data
-  if (!WIX_API_URL || !WIX_API_KEY) {
-    console.warn('WIX_API_URL or WIX_API_KEY not found. Falling back to mock data.');
-    await new Promise(resolve => setTimeout(resolve, 500));
-    const broker = mockBrokers.find(b => b.slug === slug && b.approvalStatus === 'approved' && b.isActive);
-    return broker || null;
+  if (!res.ok) {
+    throw new Error(`Failed to fetch from Wix: ${res.statusText}`);
   }
 
-  try {
-    const encodedSlug = encodeURIComponent(slug);
-    const res = await fetch(`${WIX_API_URL}/brokerProfiles?slug=${encodedSlug}&status=approved&active=true`, {
-      headers: {
-        'Authorization': `Bearer ${WIX_API_KEY}`,
-        'Content-Type': 'application/json'
-      },
-      next: { revalidate: 3600 }
-    });
-
-    if (!res.ok) {
-      throw new Error(`Failed to fetch from Wix: ${res.statusText}`);
-    }
-
-    const data: WixBrokerResponse[] = await res.json();
-    if (data.length > 0) {
-      return normalizeBroker(data[0]);
-    }
-    return null;
-  } catch (error) {
-    console.error(`Error fetching Wix broker with slug ${slug}:`, error);
-    const broker = mockBrokers.find(b => b.slug === slug && b.approvalStatus === 'approved' && b.isActive);
-    return broker || null;
+  const data: WixBrokerResponse[] = await res.json();
+  if (data.length > 0) {
+    return data[0];
   }
+  return null;
 }


### PR DESCRIPTION
This PR introduces the V1.1 update pass for the Moonshine Capital Portal. It shifts the architecture away from heavy Wix-centricity by safely handling data retrieval and mock data fallbacks in `lib/brokers.ts`. 

Key enhancements include:
- **Data Model**: Expanded the `BrokerProfile` schema and mock data with additional context parameters (deal sizes, speed to contact, proof points, etc).
- **Tracking**: Set up foundational tracking events in `/out` routing using a webhook dispatcher (`trackBrokerCtaClick`).
- **UI Expansion**: Added "Get Matched" CTAs. Added specialized blocks for "Best Fit Clients" and "Proof Points" to broker profiles to make them stronger conversion pages.
- **Workflow**: Initialized a `.github/workflows/ci.yml` to automatically lint, test, and build Next.js PRs.

All vitest specs have been adjusted and pass. Build has been statically verified.

---
*PR created automatically by Jules for task [15182311595977865100](https://jules.google.com/task/15182311595977865100) started by @JFeimster*