### PR TITLE
Add registry filtering and admin coverage views

### DIFF
--- a/app/admin/resources/page.tsx
+++ b/app/admin/resources/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { getToolsByKind } from '@/lib/embed-registry';
+import { getRegistryCoverage, getToolsByKind, groupRegistryItemsBy } from '@/lib/embed-registry';
 
 export const metadata = {
   title: 'Admin Resources | Moonshine Capital Portal',
@@ -8,19 +8,35 @@ export const metadata = {
 
 export default async function AdminResourcesPage() {
   const resources = await getToolsByKind('resource');
+  const groupedResources = groupRegistryItemsBy(resources, 'funnelStage');
+  const coverage = getRegistryCoverage(resources);
 
   return (
     <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
       <div className="mx-auto max-w-7xl space-y-6">
         <Link href="/admin" className="inline-flex border-2 border-neo-black bg-neo-white px-4 py-2 text-sm font-black uppercase tracking-wide shadow-[4px_4px_0_0_rgba(0,0,0,1)]">Back to admin</Link>
+
         <section className="card-brutal bg-neo-white">
           <h1 className="text-3xl font-black uppercase">Resource coverage</h1>
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            {Object.entries(groupedResources).map(([stage, stageResources]) => (
+              <div key={stage} className="border-2 border-neo-black p-4">
+                <p className="text-xs font-black uppercase text-neo-black/60">{stage}</p>
+                <p className="mt-2 text-3xl font-black">{stageResources.length}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="card-brutal bg-neo-white">
+          <h1 className="text-3xl font-black uppercase">Resource inventory</h1>
           <div className="mt-4 grid gap-4 md:grid-cols-2">
-            {resources.map((item) => (
+            {coverage.map(({ item, coverageScore, missingFields }) => (
               <article key={item.id} className="border-2 border-neo-black p-4">
                 <h2 className="text-xl font-black uppercase">{item.title}</h2>
                 <p className="mt-2 text-sm">{item.description}</p>
-                <p className="mt-3 text-xs font-black uppercase text-neo-black/60">{item.category} • {item.funnelStage || 'general'}</p>
+                <p className="mt-3 text-xs font-black uppercase text-neo-black/60">{item.category} • {item.funnelStage || 'general'} • score {coverageScore}</p>
+                {missingFields.length > 0 && <p className="mt-2 text-sm font-medium">Missing: {missingFields.join(', ')}</p>}
               </article>
             ))}
           </div>

--- a/app/admin/tools/page.tsx
+++ b/app/admin/tools/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { getAllRegistryItems, getRegistryStats } from '@/lib/embed-registry';
+import { getAllRegistryItems, getRegistryCoverage, getRegistryStats } from '@/lib/embed-registry';
 
 export const metadata = {
   title: 'Admin Tools | Moonshine Capital Portal',
@@ -9,6 +9,8 @@ export const metadata = {
 export default async function AdminToolsPage() {
   const items = await getAllRegistryItems();
   const stats = await getRegistryStats();
+  const coverage = getRegistryCoverage(items);
+  const weakItems = coverage.filter((row) => row.coverageScore < 90 || !row.hasDestination || !row.hasBrokerAssignments);
 
   return (
     <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
@@ -22,19 +24,37 @@ export default async function AdminToolsPage() {
             </div>
           ))}
         </section>
+
+        <section className="card-brutal bg-neo-white">
+          <h1 className="text-3xl font-black uppercase">Coverage alerts</h1>
+          <p className="mt-2 font-medium text-neo-black/70">Items here are usable but need operator attention before the registry becomes truly grown-up. Tiny clown shoes, meet data hygiene.</p>
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            {weakItems.map(({ item, missingFields, coverageScore, hasDestination, hasBrokerAssignments }) => (
+              <div key={item.id} className="border-2 border-neo-black p-4">
+                <p className="font-black uppercase">{item.title}</p>
+                <p className="mt-1 text-sm font-bold">Score: {coverageScore}</p>
+                <p className="mt-1 text-xs font-black uppercase text-neo-black/60">{item.kind} • {item.resourceType}</p>
+                <p className="mt-2 text-sm font-medium">{!hasDestination && 'Missing destination. '}{!hasBrokerAssignments && 'No broker assignments. '}{missingFields.length > 0 && `Missing: ${missingFields.join(', ')}`}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
         <section className="card-brutal bg-neo-white">
           <h1 className="text-3xl font-black uppercase">Registry inventory</h1>
           <div className="mt-4 overflow-x-auto">
             <table className="w-full text-left text-sm">
-              <thead><tr className="border-b-2 border-neo-black"><th>Title</th><th>Status</th><th>Kind</th><th>Access</th><th>Brokers</th></tr></thead>
+              <thead><tr className="border-b-2 border-neo-black"><th>Title</th><th>Status</th><th>Kind</th><th>Type</th><th>Destination</th><th>Brokers</th><th>Score</th></tr></thead>
               <tbody>
-                {items.map((item) => (
+                {coverage.map(({ item, destination, coverageScore }) => (
                   <tr key={item.id} className="border-b border-neo-black/20">
                     <td className="py-3 font-bold">{item.title}</td>
                     <td>{item.status}</td>
                     <td>{item.kind}</td>
-                    <td>{item.accessLevel}</td>
+                    <td>{item.resourceType}</td>
+                    <td className="max-w-xs truncate">{destination}</td>
                     <td>{item.brokerAssignments.length}</td>
+                    <td>{coverageScore}</td>
                   </tr>
                 ))}
               </tbody>

--- a/app/portal/resources/page.tsx
+++ b/app/portal/resources/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { getToolsByKind } from '@/lib/embed-registry';
+import { getToolsByKind, groupRegistryItemsBy } from '@/lib/embed-registry';
 import { ToolGrid } from '@/components/portal/ToolGrid';
 
 export const metadata = {
@@ -9,6 +9,7 @@ export const metadata = {
 
 export default async function PortalResourcesPage() {
   const resources = await getToolsByKind('resource');
+  const groupedResources = groupRegistryItemsBy(resources, 'funnelStage');
 
   return (
     <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
@@ -25,7 +26,9 @@ export default async function PortalResourcesPage() {
           </p>
         </section>
 
-        <ToolGrid title="Operator resources" tools={resources} emptyTitle="No resources loaded" emptyMessage="Add scripts, playbooks, and enablement assets to the registry so this stops being a pretty empty shelf." />
+        {Object.entries(groupedResources).map(([stage, stageResources]) => (
+          <ToolGrid key={stage} title={stage} tools={stageResources} emptyTitle="No resources loaded" emptyMessage="Add scripts, playbooks, and enablement assets to the registry so this stops being a pretty empty shelf." />
+        ))}
       </div>
     </main>
   );

--- a/app/portal/tools/page.tsx
+++ b/app/portal/tools/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { getFeaturedRegistryItems, getToolsByAccessLevel, getToolsForAudience } from '@/lib/embed-registry';
+import { getFeaturedRegistryItems, getToolsByAccessLevel, getToolsForAudience, groupRegistryItemsBy } from '@/lib/embed-registry';
 import { ToolGrid } from '@/components/portal/ToolGrid';
 
 export const metadata = {
@@ -11,6 +11,7 @@ export default async function PortalToolsPage() {
   const tools = await getToolsByAccessLevel('portal');
   const featured = await getFeaturedRegistryItems(3);
   const brokerTools = await getToolsForAudience('brokers');
+  const groupedTools = groupRegistryItemsBy(tools, 'category');
 
   return (
     <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
@@ -28,7 +29,16 @@ export default async function PortalToolsPage() {
 
         <ToolGrid title="Featured tools" tools={featured} />
         <ToolGrid title="Broker ops" tools={brokerTools.slice(0, 6)} />
-        <ToolGrid title="All active tools" tools={tools} emptyTitle="No portal tools active" emptyMessage="Load real Vercel apps, calculators, and GPT assets into the embed registry so this page earns its existence." />
+
+        <section className="space-y-8">
+          <div>
+            <h2 className="text-3xl font-black uppercase tracking-tight">Tool categories</h2>
+            <p className="mt-2 max-w-2xl font-medium text-neo-black/70">Scan the registry by operating lane instead of digging through one giant card pile like a raccoon in a fintech dumpster.</p>
+          </div>
+          {Object.entries(groupedTools).map(([category, categoryTools]) => (
+            <ToolGrid key={category} title={category} tools={categoryTools} />
+          ))}
+        </section>
       </div>
     </main>
   );

--- a/lib/embed-registry.ts
+++ b/lib/embed-registry.ts
@@ -56,6 +56,15 @@ export interface RegistryStats {
   missingDestination: number;
 }
 
+export interface RegistryCoverageItem {
+  item: ToolRegistryItem;
+  destination: string;
+  hasDestination: boolean;
+  hasBrokerAssignments: boolean;
+  missingFields: string[];
+  coverageScore: number;
+}
+
 async function readRegistryFile(): Promise<ToolRegistryFile> {
   const filePath = path.join(process.cwd(), 'data', 'embeds', 'tool-registry.json');
   const content = await fs.readFile(filePath, 'utf-8');
@@ -69,6 +78,45 @@ function bySortThenTitle(a: ToolRegistryItem, b: ToolRegistryItem) {
 
 function isPubliclyAvailable(item: ToolRegistryItem) {
   return item.status === 'active';
+}
+
+export function groupRegistryItemsBy(items: ToolRegistryItem[], field: 'category' | 'resourceType' | 'renderType' | 'funnelStage') {
+  return items.reduce<Record<string, ToolRegistryItem[]>>((groups, item) => {
+    const key = field === 'funnelStage' ? item.funnelStage || 'general' : item[field] || 'uncategorized';
+    groups[key] = groups[key] || [];
+    groups[key].push(item);
+    return groups;
+  }, {});
+}
+
+export function getRegistryDestination(item: ToolRegistryItem) {
+  return item.ctaHref || item.url || item.embedUrl || '#';
+}
+
+export function getRegistryCoverage(items: ToolRegistryItem[]): RegistryCoverageItem[] {
+  return items.map((item) => {
+    const destination = getRegistryDestination(item);
+    const missingFields = [
+      !item.description ? 'description' : null,
+      !item.ctaLabel ? 'ctaLabel' : null,
+      item.tags.length === 0 ? 'tags' : null,
+      item.audience.length === 0 ? 'audience' : null,
+      item.verticals.length === 0 ? 'verticals' : null,
+      item.useCases.length === 0 ? 'useCases' : null,
+      destination === '#' ? 'destination' : null,
+    ].filter(Boolean) as string[];
+
+    const coverageScore = Math.max(0, 100 - missingFields.length * 15 - (item.brokerAssignments.length === 0 ? 10 : 0));
+
+    return {
+      item,
+      destination,
+      hasDestination: destination !== '#',
+      hasBrokerAssignments: item.brokerAssignments.length > 0,
+      missingFields,
+      coverageScore,
+    };
+  });
 }
 
 export async function getAllRegistryItems(): Promise<ToolRegistryItem[]> {
@@ -149,8 +197,4 @@ export async function getRegistryStats(): Promise<RegistryStats> {
     assignedToBrokers: items.filter((item) => item.brokerAssignments.length > 0).length,
     missingDestination: items.filter((item) => !item.url && !item.embedUrl && !item.ctaHref).length,
   };
-}
-
-export function getRegistryDestination(item: ToolRegistryItem) {
-  return item.ctaHref || item.url || item.embedUrl || '#';
 }


### PR DESCRIPTION
Closes #55

## Summary
- adds shared registry grouping + coverage helpers
- groups portal tools by category
- groups portal resources by funnel stage
- adds admin coverage alerts for weak/orphaned registry items
- adds admin inventory visibility for destination + metadata gaps

## Scope
- portal/admin utility layer only
- no schema changes
- no registry CRUD
- no auth changes