### PR TITLE
Add tracked registry redirect routes

### DIFF
--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getRegistryDestination, getToolBySlug } from '@/lib/embed-registry';
+
+export async function GET(_: Request, { params }: { params: { slug: string } }) {
+  const item = await getToolBySlug(params.slug);
+
+  if (!item) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const destination = getRegistryDestination(item);
+
+  if (!destination || destination === '#') {
+    return NextResponse.json({ error: 'Missing destination' }, { status: 404 });
+  }
+
+  return NextResponse.redirect(new URL(destination, 'http://localhost:3000'));
+}

--- a/components/portal/RegistryDetailPage.tsx
+++ b/components/portal/RegistryDetailPage.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { getRegistryDestination, type ToolRegistryItem } from '@/lib/embed-registry';
+import { getRegistryDestination, getRegistryTrackedHref, type ToolRegistryItem } from '@/lib/embed-registry';
 import { ToolGrid } from '@/components/portal/ToolGrid';
 
 interface RegistryDetailPageProps {
@@ -15,6 +15,7 @@ function isExternalHref(href: string) {
 
 export function RegistryDetailPage({ item, backHref, backLabel, relatedItems = [] }: RegistryDetailPageProps) {
   const destination = getRegistryDestination(item);
+  const trackedHref = getRegistryTrackedHref(item);
   const hasAssignments = item.brokerAssignments.length > 0;
 
   return (
@@ -39,7 +40,7 @@ export function RegistryDetailPage({ item, backHref, backLabel, relatedItems = [
               <span key={tag} className="border border-neo-black bg-neo-white px-2 py-1 text-xs font-black uppercase">{tag}</span>
             ))}
           </div>
-          <a href={destination} target={isExternalHref(destination) ? '_blank' : undefined} rel={isExternalHref(destination) ? 'noopener noreferrer' : undefined} className="btn-brutal-primary mt-8 inline-flex">
+          <a href={trackedHref} target={isExternalHref(destination) ? '_blank' : undefined} rel={isExternalHref(destination) ? 'noopener noreferrer' : undefined} className="btn-brutal-primary mt-8 inline-flex">
             {item.ctaLabel}
           </a>
         </section>

--- a/lib/embed-registry.ts
+++ b/lib/embed-registry.ts
@@ -93,6 +93,10 @@ export function getRegistryDestination(item: ToolRegistryItem) {
   return item.ctaHref || item.url || item.embedUrl || '#';
 }
 
+export function getRegistryTrackedHref(item: ToolRegistryItem) {
+  return `/go/${item.slug}`;
+}
+
 export function getRegistryCoverage(items: ToolRegistryItem[]): RegistryCoverageItem[] {
   return items.map((item) => {
     const destination = getRegistryDestination(item);


### PR DESCRIPTION
Closes #59

## Summary
- adds tracked registry URL helper
- adds `/go/[slug]` redirect route
- resolves registry item by slug and redirects to destination
- returns 404 for invalid slugs or missing destinations
- routes registry detail CTAs through tracked redirects

## Scope
- tracked redirect infrastructure only
- no analytics vendor
- no database writes
- no schema changes