### PR TITLE
Add registry click event logging stub

### DIFF
--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getRegistryDestination, getToolBySlug } from '@/lib/embed-registry';
+import { trackRegistryClick } from '@/lib/registry-click-tracking';
 
 export async function GET(request: Request, { params }: { params: { slug: string } }) {
   const item = await getToolBySlug(params.slug);
@@ -13,6 +14,8 @@ export async function GET(request: Request, { params }: { params: { slug: string
   if (!destination || destination === '#') {
     return NextResponse.json({ error: 'Missing destination' }, { status: 404 });
   }
+
+  trackRegistryClick({ item, destination, request });
 
   const redirectUrl = new URL(destination, request.url);
 

--- a/lib/registry-click-tracking.ts
+++ b/lib/registry-click-tracking.ts
@@ -1,0 +1,26 @@
+import type { ToolRegistryItem } from '@/lib/embed-registry';
+
+interface TrackRegistryClickInput {
+  item: ToolRegistryItem;
+  destination: string;
+  request: Request;
+}
+
+export function trackRegistryClick({ item, destination, request }: TrackRegistryClickInput) {
+  const event = {
+    event: 'registry_click',
+    slug: item.slug,
+    itemId: item.id,
+    kind: item.kind,
+    category: item.category,
+    resourceType: item.resourceType,
+    destination,
+    timestamp: new Date().toISOString(),
+    referrer: request.headers.get('referer') || null,
+    userAgent: request.headers.get('user-agent') || null,
+  };
+
+  console.info('[registry-click]', event);
+
+  return event;
+}


### PR DESCRIPTION
Closes #63

## Summary
- adds isolated `trackRegistryClick()` server helper
- emits structured server-side click events for registry redirects
- captures slug, item id, kind, category, destination, timestamp, referrer, and user-agent
- wires click logging into `/go/[slug]` before redirecting

## Scope
- logging stub only
- no database writes
- no analytics vendor
- no schema changes