### PR TITLE
Add registry click webhook sink

### DIFF
--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: Request, { params }: { params: { slug: string
     return NextResponse.json({ error: 'Missing destination' }, { status: 404 });
   }
 
-  trackRegistryClick({ item, destination, request });
+  await trackRegistryClick({ item, destination, request });
 
   const redirectUrl = new URL(destination, request.url);
 

--- a/lib/registry-click-tracking.ts
+++ b/lib/registry-click-tracking.ts
@@ -6,8 +6,46 @@ interface TrackRegistryClickInput {
   request: Request;
 }
 
-export function trackRegistryClick({ item, destination, request }: TrackRegistryClickInput) {
-  const event = {
+export interface RegistryClickEvent {
+  event: 'registry_click';
+  slug: string;
+  itemId: string;
+  kind: ToolRegistryItem['kind'];
+  category: string;
+  resourceType: string;
+  destination: string;
+  timestamp: string;
+  referrer: string | null;
+  userAgent: string | null;
+}
+
+async function sendRegistryClickWebhook(event: RegistryClickEvent) {
+  const webhookUrl = process.env.REGISTRY_CLICK_WEBHOOK_URL;
+
+  if (!webhookUrl) return;
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(event),
+    });
+
+    if (!response.ok) {
+      console.warn('[registry-click-webhook-failed]', {
+        status: response.status,
+        statusText: response.statusText,
+      });
+    }
+  } catch (error) {
+    console.warn('[registry-click-webhook-error]', error);
+  }
+}
+
+export async function trackRegistryClick({ item, destination, request }: TrackRegistryClickInput) {
+  const event: RegistryClickEvent = {
     event: 'registry_click',
     slug: item.slug,
     itemId: item.id,
@@ -21,6 +59,8 @@ export function trackRegistryClick({ item, destination, request }: TrackRegistry
   };
 
   console.info('[registry-click]', event);
+
+  await sendRegistryClickWebhook(event);
 
   return event;
 }


### PR DESCRIPTION
Closes #67

## Summary
- adds optional webhook sink for registry click events
- keeps structured console logging as baseline behavior
- POSTs click events to `REGISTRY_CLICK_WEBHOOK_URL` when configured
- fails open so redirects are never blocked by tracking failures

## Scope
- no database writes
- no analytics vendor
- no schema changes
- n8n-ready event forwarding