### PR TITLE
Add timeout to registry click webhook sink

### DIFF
--- a/lib/registry-click-tracking.ts
+++ b/lib/registry-click-tracking.ts
@@ -19,6 +19,8 @@ export interface RegistryClickEvent {
   userAgent: string | null;
 }
 
+const REGISTRY_CLICK_WEBHOOK_TIMEOUT_MS = 1500;
+
 async function sendRegistryClickWebhook(event: RegistryClickEvent) {
   const webhookUrl = process.env.REGISTRY_CLICK_WEBHOOK_URL;
 
@@ -31,6 +33,7 @@ async function sendRegistryClickWebhook(event: RegistryClickEvent) {
         'content-type': 'application/json',
       },
       body: JSON.stringify(event),
+      signal: AbortSignal.timeout(REGISTRY_CLICK_WEBHOOK_TIMEOUT_MS),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
Closes #69

## Summary
- adds a bounded timeout to registry click webhook POSTs
- preserves console logging behavior
- preserves fail-open webhook behavior
- prevents slow webhook sinks from delaying `/go/[slug]` redirects

## Scope
- timeout safety patch only
- no schema changes
- no analytics changes
- no dashboard changes