### PR TITLE
Update admin brokers page with live broker utility coverage

### DIFF
--- a/app/admin/brokers/page.tsx
+++ b/app/admin/brokers/page.tsx
@@ -3,31 +3,53 @@ import { BrokerStatusToggle } from '@/components/admin/BrokerStatusToggle';
 import { getBrokers } from '@/lib/brokers';
 import { getToolsForBroker } from '@/lib/embed-registry';
 
+export const dynamic = 'force-dynamic';
+
 export const metadata = {
   title: 'Admin Brokers | Moonshine Capital Portal',
   description: 'Broker management layer for status, quality, and visibility controls.',
 };
 
+interface BrokerCoverageRow {
+  name: string;
+  slug: string;
+  status: string;
+  assignedTools: number;
+  featuredAssignments: number;
+  fallback: boolean;
+}
+
+async function getBrokerCoverageRows(): Promise<{ rows: BrokerCoverageRow[]; loadFailed: boolean }> {
+  try {
+    const brokers = await getBrokers();
+
+    const rows = await Promise.all(
+      brokers.map(async (broker) => {
+        const assignedTools = await getToolsForBroker(broker.slug);
+        const featuredAssignments = assignedTools.filter((tool) =>
+          tool.brokerAssignments.some((assignment) => assignment.brokerSlug === broker.slug && assignment.featured),
+        ).length;
+
+        return {
+          name: broker.fullName,
+          slug: broker.slug,
+          status: broker.status || 'unknown',
+          assignedTools: assignedTools.length,
+          featuredAssignments,
+          fallback: assignedTools.length === 0,
+        };
+      }),
+    );
+
+    return { rows, loadFailed: false };
+  } catch (error) {
+    console.warn('[admin-brokers-load-failed]', error);
+    return { rows: [], loadFailed: true };
+  }
+}
+
 export default async function AdminBrokersPage() {
-  const brokers = await getBrokers();
-
-  const brokerRows = await Promise.all(
-    brokers.map(async (broker) => {
-      const assignedTools = await getToolsForBroker(broker.slug);
-      const featuredAssignments = assignedTools.filter((tool) =>
-        tool.brokerAssignments.some((assignment) => assignment.brokerSlug === broker.slug && assignment.featured),
-      ).length;
-
-      return {
-        name: broker.fullName,
-        slug: broker.slug,
-        status: broker.status || 'unknown',
-        assignedTools: assignedTools.length,
-        featuredAssignments,
-        fallback: assignedTools.length === 0,
-      };
-    }),
-  );
+  const { rows: brokerRows, loadFailed } = await getBrokerCoverageRows();
 
   return (
     <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
@@ -44,6 +66,15 @@ export default async function AdminBrokersPage() {
           </p>
         </section>
 
+        {loadFailed && (
+          <section className="border-4 border-neo-black bg-neo-yellow p-5 shadow-[8px_8px_0_0_rgba(0,0,0,1)]">
+            <h2 className="text-2xl font-black uppercase">Broker data unavailable</h2>
+            <p className="mt-2 font-bold text-neo-black/80">
+              The admin broker coverage page loaded, but broker source data could not be fetched. Check Wix/API environment variables or upstream availability.
+            </p>
+          </section>
+        )}
+
         <section className="grid gap-6 lg:grid-cols-[1.5fr_0.5fr]">
           <div className="overflow-hidden border-4 border-neo-black bg-neo-white shadow-[10px_10px_0_0_rgba(0,0,0,1)]">
             <div className="grid grid-cols-6 border-b-4 border-neo-black bg-neo-black px-5 py-4 text-xs font-black uppercase tracking-wide text-neo-white">
@@ -54,18 +85,24 @@ export default async function AdminBrokersPage() {
               <span>Featured</span>
               <span>Profile</span>
             </div>
-            {brokerRows.map((row) => (
-              <div key={row.slug} className="grid grid-cols-6 items-center border-b-2 border-neo-black px-5 py-4 text-sm font-bold uppercase tracking-wide last:border-b-0">
-                <span>{row.name}</span>
-                <span>{row.slug}</span>
-                <span>{row.status}</span>
-                <span>{row.assignedTools}</span>
-                <span>{row.featuredAssignments}</span>
-                <Link href={`/directory/${row.slug}`} className="underline">
-                  {row.fallback ? 'Fallback' : 'Live'}
-                </Link>
+            {brokerRows.length > 0 ? (
+              brokerRows.map((row) => (
+                <div key={row.slug} className="grid grid-cols-6 items-center border-b-2 border-neo-black px-5 py-4 text-sm font-bold uppercase tracking-wide last:border-b-0">
+                  <span>{row.name}</span>
+                  <span>{row.slug}</span>
+                  <span>{row.status}</span>
+                  <span>{row.assignedTools}</span>
+                  <span>{row.featuredAssignments}</span>
+                  <Link href={`/directory/${row.slug}`} className="underline">
+                    {row.fallback ? 'Fallback' : 'Live'}
+                  </Link>
+                </div>
+              ))
+            ) : (
+              <div className="border-b-2 border-neo-black px-5 py-6 text-sm font-bold uppercase tracking-wide last:border-b-0">
+                No broker rows available. The page is guarded so deployment does not fail when upstream broker data is unavailable.
               </div>
-            ))}
+            )}
           </div>
 
           <BrokerStatusToggle currentStatus="approved" />

--- a/app/admin/brokers/page.tsx
+++ b/app/admin/brokers/page.tsx
@@ -1,18 +1,34 @@
 import Link from 'next/link';
 import { BrokerStatusToggle } from '@/components/admin/BrokerStatusToggle';
+import { getBrokers } from '@/lib/brokers';
+import { getToolsForBroker } from '@/lib/embed-registry';
 
 export const metadata = {
   title: 'Admin Brokers | Moonshine Capital Portal',
   description: 'Broker management layer for status, quality, and visibility controls.',
 };
 
-const brokerRows = [
-  { name: 'Darwin Hanneman', slug: 'darwin-hanneman', status: 'approved' },
-  { name: 'Sample Broker', slug: 'sample-broker', status: 'in_review' },
-  { name: 'Pending Broker', slug: 'pending-broker', status: 'pending' },
-];
+export default async function AdminBrokersPage() {
+  const brokers = await getBrokers();
 
-export default function AdminBrokersPage() {
+  const brokerRows = await Promise.all(
+    brokers.map(async (broker) => {
+      const assignedTools = await getToolsForBroker(broker.slug);
+      const featuredAssignments = assignedTools.filter((tool) =>
+        tool.brokerAssignments.some((assignment) => assignment.brokerSlug === broker.slug && assignment.featured),
+      ).length;
+
+      return {
+        name: broker.fullName,
+        slug: broker.slug,
+        status: broker.status || 'unknown',
+        assignedTools: assignedTools.length,
+        featuredAssignments,
+        fallback: assignedTools.length === 0,
+      };
+    }),
+  );
+
   return (
     <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
       <div className="mx-auto max-w-7xl space-y-6">
@@ -22,24 +38,32 @@ export default function AdminBrokersPage() {
 
         <section className="border-4 border-neo-black bg-neo-white p-6 shadow-[12px_12px_0_0_rgba(0,0,0,1)]">
           <span className="border-2 border-neo-black bg-neo-green px-3 py-1 text-xs font-black uppercase tracking-wide">Brokers</span>
-          <h1 className="mt-4 text-4xl font-black uppercase tracking-tight md:text-5xl">Manage broker state and profile quality.</h1>
-          <p className="mt-3 max-w-3xl text-base font-medium leading-relaxed text-neo-black/80">
-            This should become the working control panel for approval, public visibility, profile quality, resource assignment, and downstream publishing rules.
+          <h1 className="mt-4 text-4xl font-black uppercase tracking-tight md:text-5xl">Broker utility coverage and profile state.</h1>
+          <p className="mt-3 max-w-4xl text-base font-medium leading-relaxed text-neo-black/80">
+            Read-only broker coverage surface for profile visibility, assigned tools, featured utility depth, and fallback exposure. This is the operator view for broker utility quality before CRUD or sync workflows exist.
           </p>
         </section>
 
-        <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+        <section className="grid gap-6 lg:grid-cols-[1.5fr_0.5fr]">
           <div className="overflow-hidden border-4 border-neo-black bg-neo-white shadow-[10px_10px_0_0_rgba(0,0,0,1)]">
-            <div className="grid grid-cols-3 border-b-4 border-neo-black bg-neo-black px-5 py-4 text-xs font-black uppercase tracking-wide text-neo-white">
+            <div className="grid grid-cols-6 border-b-4 border-neo-black bg-neo-black px-5 py-4 text-xs font-black uppercase tracking-wide text-neo-white">
               <span>Name</span>
               <span>Slug</span>
               <span>Status</span>
+              <span>Assigned</span>
+              <span>Featured</span>
+              <span>Profile</span>
             </div>
             {brokerRows.map((row) => (
-              <div key={row.slug} className="grid grid-cols-3 border-b-2 border-neo-black px-5 py-4 text-sm font-bold uppercase tracking-wide last:border-b-0">
+              <div key={row.slug} className="grid grid-cols-6 items-center border-b-2 border-neo-black px-5 py-4 text-sm font-bold uppercase tracking-wide last:border-b-0">
                 <span>{row.name}</span>
                 <span>{row.slug}</span>
                 <span>{row.status}</span>
+                <span>{row.assignedTools}</span>
+                <span>{row.featuredAssignments}</span>
+                <Link href={`/directory/${row.slug}`} className="underline">
+                  {row.fallback ? 'Fallback' : 'Live'}
+                </Link>
               </div>
             ))}
           </div>

--- a/app/admin/brokers/page.tsx
+++ b/app/admin/brokers/page.tsx
@@ -13,7 +13,6 @@ export const metadata = {
 interface BrokerCoverageRow {
   name: string;
   slug: string;
-  status: string;
   assignedTools: number;
   featuredAssignments: number;
   fallback: boolean;
@@ -33,7 +32,6 @@ async function getBrokerCoverageRows(): Promise<{ rows: BrokerCoverageRow[]; loa
         return {
           name: broker.fullName,
           slug: broker.slug,
-          status: broker.status || 'unknown',
           assignedTools: assignedTools.length,
           featuredAssignments,
           fallback: assignedTools.length === 0,
@@ -77,20 +75,18 @@ export default async function AdminBrokersPage() {
 
         <section className="grid gap-6 lg:grid-cols-[1.5fr_0.5fr]">
           <div className="overflow-hidden border-4 border-neo-black bg-neo-white shadow-[10px_10px_0_0_rgba(0,0,0,1)]">
-            <div className="grid grid-cols-6 border-b-4 border-neo-black bg-neo-black px-5 py-4 text-xs font-black uppercase tracking-wide text-neo-white">
+            <div className="grid grid-cols-5 border-b-4 border-neo-black bg-neo-black px-5 py-4 text-xs font-black uppercase tracking-wide text-neo-white">
               <span>Name</span>
               <span>Slug</span>
-              <span>Status</span>
               <span>Assigned</span>
               <span>Featured</span>
               <span>Profile</span>
             </div>
             {brokerRows.length > 0 ? (
               brokerRows.map((row) => (
-                <div key={row.slug} className="grid grid-cols-6 items-center border-b-2 border-neo-black px-5 py-4 text-sm font-bold uppercase tracking-wide last:border-b-0">
+                <div key={row.slug} className="grid grid-cols-5 items-center border-b-2 border-neo-black px-5 py-4 text-sm font-bold uppercase tracking-wide last:border-b-0">
                   <span>{row.name}</span>
                   <span>{row.slug}</span>
-                  <span>{row.status}</span>
                   <span>{row.assignedTools}</span>
                   <span>{row.featuredAssignments}</span>
                   <Link href={`/directory/${row.slug}`} className="underline">


### PR DESCRIPTION
Closes #76

## Summary
- replaces placeholder broker rows in `/admin/brokers`
- loads live brokers from `getBrokers()`
- loads assigned broker tools from registry
- shows broker utility coverage, featured assignments, fallback status, and public profile links
- keeps page read-only

## Scope
- admin broker coverage UX update only
- no CRUD
- no auth changes
- no database writes