### PR TITLE
Fix public application CTA hierarchy and nav links

### DIFF
--- a/components/CTASection.tsx
+++ b/components/CTASection.tsx
@@ -13,9 +13,14 @@ export function CTASection() {
         <p className="text-xl md:text-2xl font-black mb-12">
           Connect with an operator who understands your business and gets deals funded.
         </p>
-        <Link href="/directory" className="btn-brutal bg-neo-black text-neo-white text-xl px-12 py-6 border-4 border-neo-black shadow-[6px_6px_0px_0px_rgba(244,244,240,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all">
-          Find a Partner Now
-        </Link>
+        <div className="flex flex-col sm:flex-row gap-6 justify-center">
+          <Link href="/apply" className="btn-brutal bg-neo-black text-neo-white text-xl px-12 py-6 border-4 border-neo-black shadow-[6px_6px_0px_0px_rgba(244,244,240,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all">
+            Get Funding Now
+          </Link>
+          <Link href="/apply/quote" className="btn-brutal bg-neo-white text-neo-black text-xl px-12 py-6 border-4 border-neo-black shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:shadow-none hover:translate-y-1 hover:translate-x-1 transition-all">
+            Get a Fast Quote
+          </Link>
+        </div>
       </div>
     </section>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export function Footer() {
   return (
     <footer className="bg-neo-black text-neo-white py-12 px-6 md:px-12 border-t-4 border-neo-yellow">
@@ -13,13 +15,14 @@ export function Footer() {
         <div className="flex gap-12">
           <div className="flex flex-col gap-2">
             <h3 className="font-bold text-neo-blue uppercase tracking-wide mb-2">Platform</h3>
-            <a href="/directory" className="hover:text-neo-yellow transition-colors font-semibold">Directory</a>
-            <a href="/onboarding" className="hover:text-neo-yellow transition-colors font-semibold">Apply</a>
+            <Link href="/apply" className="hover:text-neo-yellow transition-colors font-semibold">Get Funding</Link>
+            <Link href="/directory" className="hover:text-neo-yellow transition-colors font-semibold">Directory</Link>
+            <Link href="/onboarding" className="hover:text-neo-yellow transition-colors font-semibold">Become a Partner</Link>
           </div>
           <div className="flex flex-col gap-2">
             <h3 className="font-bold text-neo-pink uppercase tracking-wide mb-2">Legal</h3>
-            <a href="/terms" className="hover:text-neo-yellow transition-colors font-semibold">Terms</a>
-            <a href="/privacy" className="hover:text-neo-yellow transition-colors font-semibold">Privacy</a>
+            <Link href="/terms" className="hover:text-neo-yellow transition-colors font-semibold">Terms</Link>
+            <Link href="/privacy" className="hover:text-neo-yellow transition-colors font-semibold">Privacy</Link>
           </div>
         </div>
       </div>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -16,8 +16,14 @@ export function HeroSection() {
           No fluff. No slow banks. Just operators who know how to move money. Built for founders who do not have time for institutional theater.
         </p>
         <div className="flex flex-wrap gap-4">
-          <Link href="/directory" className="btn-brutal-primary text-lg px-8 py-4">
-            Browse Directory
+          <Link href="/apply" className="btn-brutal-primary text-lg px-8 py-4">
+            Get Funding
+          </Link>
+          <Link href="/apply/quote" className="btn-brutal text-lg px-8 py-4">
+            Get a Fast Quote
+          </Link>
+          <Link href="/directory" className="btn-brutal text-lg px-8 py-4">
+            Browse Partners
           </Link>
           <Link href="/onboarding" className="btn-brutal text-lg px-8 py-4">
             Become a Partner

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -7,6 +7,9 @@ export function Navbar() {
         Distilled Funding
       </Link>
       <div className="flex gap-6 items-center font-bold text-sm">
+        <Link href="/apply" className="hover:text-neo-blue transition-colors uppercase tracking-wide">
+          Get Funding
+        </Link>
         <Link href="/directory" className="hover:text-neo-blue transition-colors uppercase tracking-wide">
           Directory
         </Link>


### PR DESCRIPTION
Fix public application CTA hierarchy and nav links

- Updated Hero section to prioritize "Get Funding" (/apply) and "Get a Fast Quote" (/apply/quote).
- Added "Get Funding" (/apply) to the Navbar.
- Updated Footer links to use Next.js Link component and correctly point to /apply for "Get Funding" and /onboarding for "Become a Partner".
- Replaced the single "Find a Partner Now" CTA on the homepage with dual CTAs for "Get Funding Now" and "Get a Fast Quote".
- All original visual styles (neo-brutalism) and functionality are maintained.

Closes #71

---
*PR created automatically by Jules for task [10247934180335690376](https://jules.google.com/task/10247934180335690376) started by @JFeimster*