### PR TITLE
Fix admin application registry IDs

### DIFF
--- a/app/admin/applications/page.tsx
+++ b/app/admin/applications/page.tsx
@@ -16,7 +16,7 @@ const applicationRoutes = [
     audience: 'Urgent applicants optimizing for speed',
     purpose: 'Quickest funding path for speed-first applicants who need fast routing.',
     tally: 'Fast-lane intake form',
-    registry: 'fast-track-application',
+    registry: 'fast-application',
     nextStep: 'Prioritize speed lane, normalize source, handoff to intake workflow.',
   },
   {
@@ -25,7 +25,7 @@ const applicationRoutes = [
     audience: 'Applicants who need a quote before full intake',
     purpose: 'Lightweight quote-first path for lower-friction lead capture.',
     tally: 'Quote-first lead form',
-    registry: 'quote-request',
+    registry: 'personalized-quote',
     nextStep: 'Collect estimate request, qualify, then route to full application if viable.',
   },
 ];


### PR DESCRIPTION
Closes #81

## Summary
- fixes stale registry IDs in `/admin/applications`
- updates `/apply/fast` registry link to `fast-application`
- updates `/apply/quote` registry link to `personalized-quote`
- keeps intake map aligned with `data/embeds/tool-registry.json`

## Scope
- small admin data integrity fix only
- no route changes
- no schema changes
- no UI redesign