### PR TITLE
Add filters to portal tools page

### DIFF
--- a/app/portal/tools/page.tsx
+++ b/app/portal/tools/page.tsx
@@ -7,11 +7,18 @@ export const metadata = {
   description: 'Curated broker tool library inside the portal.',
 };
 
+function uniqueValues(values: string[][]) {
+  return Array.from(new Set(values.flat().filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
 export default async function PortalToolsPage() {
   const tools = await getToolsByAccessLevel('portal');
   const featured = await getFeaturedRegistryItems(3);
   const brokerTools = await getToolsForAudience('brokers');
   const groupedTools = groupRegistryItemsBy(tools, 'category');
+  const categories = Object.keys(groupedTools).sort((a, b) => a.localeCompare(b));
+  const audiences = uniqueValues(tools.map((tool) => tool.audience));
+  const verticals = uniqueValues(tools.map((tool) => tool.verticals));
 
   return (
     <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
@@ -27,6 +34,42 @@ export default async function PortalToolsPage() {
           </p>
         </section>
 
+        <section className="grid gap-4 md:grid-cols-3">
+          <div className="card-brutal bg-neo-white">
+            <p className="text-xs font-black uppercase">Categories</p>
+            <h2 className="mt-2 text-3xl font-black uppercase">{categories.length}</h2>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {categories.map((category) => (
+                <a key={category} href={`#category-${category}`} className="border-2 border-neo-black bg-neo-yellow px-2 py-1 text-xs font-black uppercase">
+                  {category}
+                </a>
+              ))}
+            </div>
+          </div>
+          <div className="card-brutal bg-neo-white">
+            <p className="text-xs font-black uppercase">Audiences</p>
+            <h2 className="mt-2 text-3xl font-black uppercase">{audiences.length}</h2>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {audiences.slice(0, 12).map((audience) => (
+                <span key={audience} className="border-2 border-neo-black bg-neo-white px-2 py-1 text-xs font-black uppercase">
+                  {audience}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="card-brutal bg-neo-white">
+            <p className="text-xs font-black uppercase">Verticals</p>
+            <h2 className="mt-2 text-3xl font-black uppercase">{verticals.length}</h2>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {verticals.slice(0, 12).map((vertical) => (
+                <span key={vertical} className="border-2 border-neo-black bg-neo-pink px-2 py-1 text-xs font-black uppercase">
+                  {vertical}
+                </span>
+              ))}
+            </div>
+          </div>
+        </section>
+
         <ToolGrid title="Featured tools" tools={featured} />
         <ToolGrid title="Broker ops" tools={brokerTools.slice(0, 6)} />
 
@@ -36,7 +79,9 @@ export default async function PortalToolsPage() {
             <p className="mt-2 max-w-2xl font-medium text-neo-black/70">Scan the registry by operating lane instead of digging through one giant card pile like a raccoon in a fintech dumpster.</p>
           </div>
           {Object.entries(groupedTools).map(([category, categoryTools]) => (
-            <ToolGrid key={category} title={category} tools={categoryTools} />
+            <div key={category} id={`category-${category}`} className="scroll-mt-10">
+              <ToolGrid title={category} tools={categoryTools} />
+            </div>
           ))}
         </section>
       </div>


### PR DESCRIPTION
Closes #87

## Summary
- adds filter summary surfaces to `/portal/tools`
- surfaces category jump links for faster browsing
- exposes audience and vertical metadata in-page
- preserves read-only registry browsing and existing tool grid behavior

## Scope
- portal tools UX only
- no auth changes
- no CRUD
- no analytics changes