### PR TITLE
Add broker-aware tool recommendations to portal profile

### DIFF
--- a/app/portal/profile/page.tsx
+++ b/app/portal/profile/page.tsx
@@ -1,9 +1,13 @@
 import Link from 'next/link';
+import { ToolGrid } from '@/components/portal/ToolGrid';
+import { getFeaturedRegistryItems, getToolsForBroker } from '@/lib/embed-registry';
 
 export const metadata = {
   title: 'Portal Profile | Moonshine Capital Portal',
   description: 'Broker-facing profile management and completion layer.',
 };
+
+const fallbackBrokerSlug = 'darwin-hanneman';
 
 const profileChecklist = [
   'Add positioning statement that does not sound like generic broker mush',
@@ -12,7 +16,12 @@ const profileChecklist = [
   'Review public profile before sharing it',
 ];
 
-export default function PortalProfilePage() {
+export default async function PortalProfilePage() {
+  const assignedTools = await getToolsForBroker(fallbackBrokerSlug);
+  const fallbackTools = assignedTools.length > 0 ? [] : await getFeaturedRegistryItems(3);
+  const recommendedTools = assignedTools.length > 0 ? assignedTools : fallbackTools;
+  const recommendationMode = assignedTools.length > 0 ? 'Broker-assigned stack' : 'Fallback featured stack';
+
   return (
     <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
       <div className="mx-auto max-w-7xl space-y-6">
@@ -24,7 +33,7 @@ export default function PortalProfilePage() {
           <span className="border-2 border-neo-black bg-neo-green px-3 py-1 text-xs font-black uppercase tracking-wide">Profile</span>
           <h1 className="mt-4 text-4xl font-black uppercase tracking-tight md:text-5xl">Build a profile worth sharing.</h1>
           <p className="mt-3 max-w-3xl text-base font-medium leading-relaxed text-neo-black/80">
-            This page should help brokers polish positioning, control CTA behavior, assign resources, and preview what the public actually sees.
+            This page helps brokers polish positioning, inspect assigned utility, and preview what the public actually sees. Auth-aware profile context comes later; for now this uses a safe broker-aware fallback path.
           </p>
         </section>
 
@@ -34,8 +43,11 @@ export default function PortalProfilePage() {
             <div className="mt-5 border-4 border-dashed border-neo-black p-6">
               <p className="text-sm font-black uppercase tracking-wide text-neo-black/65">Preview block</p>
               <p className="mt-3 text-base font-medium leading-relaxed text-neo-black/80">
-                Replace this with a live preview component once broker profile + assigned resources + tool registry are all wired together.
+                Current broker context: <strong>{fallbackBrokerSlug}</strong>. Replace this fallback with authenticated broker profile context once portal auth is wired.
               </p>
+              <Link href={`/directory/${fallbackBrokerSlug}`} className="mt-4 inline-flex border-2 border-neo-black bg-neo-black px-4 py-2 text-xs font-black uppercase tracking-wide text-neo-white">
+                Open public profile
+              </Link>
             </div>
           </article>
 
@@ -49,6 +61,24 @@ export default function PortalProfilePage() {
               ))}
             </ul>
           </article>
+        </section>
+
+        <section className="border-4 border-neo-black bg-neo-white p-6 shadow-[8px_8px_0_0_rgba(0,0,0,1)]">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div>
+              <p className="text-xs font-black uppercase tracking-wide">{recommendationMode}</p>
+              <h2 className="mt-2 text-3xl font-black uppercase tracking-tight">Recommended broker tools</h2>
+              <p className="mt-2 max-w-3xl font-medium text-neo-black/70">
+                These tools should be the first utility stack a broker sees when managing their profile. Tool clicks can move through tracked redirect paths once the profile action layer is fully wired.
+              </p>
+            </div>
+            <Link href="/portal/tools" className="border-2 border-neo-black bg-neo-green px-4 py-2 text-xs font-black uppercase tracking-wide shadow-[4px_4px_0_0_rgba(0,0,0,1)]">
+              Browse all tools
+            </Link>
+          </div>
+          <div className="mt-6">
+            <ToolGrid title="Profile utility stack" tools={recommendedTools.slice(0, 6)} />
+          </div>
         </section>
       </div>
     </main>


### PR DESCRIPTION
Closes #89

## Summary
- adds broker-aware tool recommendations to `/portal/profile`
- uses existing registry assignment logic
- falls back safely when no broker-specific assignments resolve
- keeps portal profile read-only and utility-focused

## Scope
- portal profile UX only
- no auth changes
- no CRUD
- no schema changes