### PR TITLE
Add broker-aware resource recommendations to portal profile

### DIFF
--- a/app/portal/profile/page.tsx
+++ b/app/portal/profile/page.tsx
@@ -1,6 +1,11 @@
 import Link from 'next/link';
 import { ToolGrid } from '@/components/portal/ToolGrid';
-import { getFeaturedRegistryItems, getToolsForBroker } from '@/lib/embed-registry';
+import {
+  getFeaturedRegistryItems,
+  getFeaturedResources,
+  getResourcesForBroker,
+  getToolsForBroker,
+} from '@/lib/embed-registry';
 
 export const metadata = {
   title: 'Portal Profile | Moonshine Capital Portal',
@@ -21,6 +26,11 @@ export default async function PortalProfilePage() {
   const fallbackTools = assignedTools.length > 0 ? [] : await getFeaturedRegistryItems(3);
   const recommendedTools = assignedTools.length > 0 ? assignedTools : fallbackTools;
   const recommendationMode = assignedTools.length > 0 ? 'Broker-assigned stack' : 'Fallback featured stack';
+
+  const assignedResources = await getResourcesForBroker(fallbackBrokerSlug);
+  const fallbackResources = assignedResources.length > 0 ? [] : await getFeaturedResources(3);
+  const recommendedResources = assignedResources.length > 0 ? assignedResources : fallbackResources;
+  const resourceRecommendationMode = assignedResources.length > 0 ? 'Broker-assigned resource stack' : 'Fallback featured resource stack';
 
   return (
     <main className="min-h-screen bg-neo-cream px-6 py-10 text-neo-black md:px-10">
@@ -78,6 +88,29 @@ export default async function PortalProfilePage() {
           </div>
           <div className="mt-6">
             <ToolGrid title="Profile utility stack" tools={recommendedTools.slice(0, 6)} />
+          </div>
+        </section>
+
+        <section className="border-4 border-neo-black bg-neo-white p-6 shadow-[8px_8px_0_0_rgba(0,0,0,1)]">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div>
+              <p className="text-xs font-black uppercase tracking-wide">{resourceRecommendationMode}</p>
+              <h2 className="mt-2 text-3xl font-black uppercase tracking-tight">Recommended broker resources</h2>
+              <p className="mt-2 max-w-3xl font-medium text-neo-black/70">
+                Scripts, guides, handoff assets, and enablement resources should sit next to the tool stack so brokers can act without hunting through another digital junk drawer.
+              </p>
+            </div>
+            <Link href="/portal/resources" className="border-2 border-neo-black bg-neo-yellow px-4 py-2 text-xs font-black uppercase tracking-wide shadow-[4px_4px_0_0_rgba(0,0,0,1)]">
+              Browse resources
+            </Link>
+          </div>
+          <div className="mt-6">
+            <ToolGrid
+              title="Profile resource stack"
+              tools={recommendedResources.slice(0, 6)}
+              emptyTitle="No broker resources assigned yet"
+              emptyCopy="Assign scripts, guides, handoff assets, or playbooks in the registry so this profile becomes useful instead of ornamental fintech wallpaper."
+            />
           </div>
         </section>
       </div>

--- a/lib/embed-registry.ts
+++ b/lib/embed-registry.ts
@@ -80,6 +80,21 @@ function isPubliclyAvailable(item: ToolRegistryItem) {
   return item.status === 'active';
 }
 
+function isAssignedToBroker(item: ToolRegistryItem, brokerSlug: string) {
+  return item.brokerAssignments.some((assignment) => assignment.brokerSlug === brokerSlug);
+}
+
+function sortBrokerAssignedItems(brokerSlug: string) {
+  return (a: ToolRegistryItem, b: ToolRegistryItem) => {
+    const aAssignment = a.brokerAssignments.find((assignment) => assignment.brokerSlug === brokerSlug);
+    const bAssignment = b.brokerAssignments.find((assignment) => assignment.brokerSlug === brokerSlug);
+    if (Boolean(aAssignment?.featured) !== Boolean(bAssignment?.featured)) {
+      return aAssignment?.featured ? -1 : 1;
+    }
+    return bySortThenTitle(a, b);
+  };
+}
+
 export function groupRegistryItemsBy(items: ToolRegistryItem[], field: 'category' | 'resourceType' | 'renderType' | 'funnelStage') {
   return items.reduce<Record<string, ToolRegistryItem[]>>((groups, item) => {
     const key = field === 'funnelStage' ? item.funnelStage || 'general' : item[field] || 'uncategorized';
@@ -158,6 +173,12 @@ export async function getFeaturedRegistryItems(limit?: number): Promise<ToolRegi
   return typeof limit === 'number' ? featured.slice(0, limit) : featured;
 }
 
+export async function getFeaturedResources(limit?: number): Promise<ToolRegistryItem[]> {
+  const resources = await getToolsByKind('resource');
+  const featured = resources.filter((item) => item.featured);
+  return typeof limit === 'number' ? featured.slice(0, limit) : featured;
+}
+
 export async function getToolBySlug(slug: string): Promise<ToolRegistryItem | null> {
   const items = await getAllRegistryItems();
   return items.find((item) => item.slug === slug) ?? null;
@@ -166,15 +187,17 @@ export async function getToolBySlug(slug: string): Promise<ToolRegistryItem | nu
 export async function getToolsForBroker(brokerSlug: string): Promise<ToolRegistryItem[]> {
   const items = await getActiveTools();
   return items
-    .filter((item) => item.brokerAssignments.some((assignment) => assignment.brokerSlug === brokerSlug))
-    .sort((a, b) => {
-      const aAssignment = a.brokerAssignments.find((assignment) => assignment.brokerSlug === brokerSlug);
-      const bAssignment = b.brokerAssignments.find((assignment) => assignment.brokerSlug === brokerSlug);
-      if (Boolean(aAssignment?.featured) !== Boolean(bAssignment?.featured)) {
-        return aAssignment?.featured ? -1 : 1;
-      }
-      return bySortThenTitle(a, b);
-    });
+    .filter((item) => item.kind === 'tool')
+    .filter((item) => isAssignedToBroker(item, brokerSlug))
+    .sort(sortBrokerAssignedItems(brokerSlug));
+}
+
+export async function getResourcesForBroker(brokerSlug: string): Promise<ToolRegistryItem[]> {
+  const items = await getActiveTools();
+  return items
+    .filter((item) => item.kind === 'resource')
+    .filter((item) => isAssignedToBroker(item, brokerSlug))
+    .sort(sortBrokerAssignedItems(brokerSlug));
 }
 
 export async function getToolsForVertical(vertical: string): Promise<ToolRegistryItem[]> {


### PR DESCRIPTION
## Summary
- Adds registry helpers for broker-assigned resources and featured resource fallback.
- Updates `/portal/profile` to show a broker-aware recommended resource stack below the recommended tools stack.
- Keeps the current fallback broker slug behavior intact until the broker context resolver task is implemented separately.

## Scope
- Read-only portal profile utility layer.
- Existing registry-backed data only.
- No auth changes.
- No CRUD.
- No schema changes.
- No database writes.
- No Wix sync.

## Validation
- Not run locally through connector. Vercel/GitHub checks should validate `npm run build`.

Closes #91.