### PR TITLE
Add active broker context resolver for portal profile

### DIFF
--- a/app/portal/profile/page.tsx
+++ b/app/portal/profile/page.tsx
@@ -6,13 +6,12 @@ import {
   getResourcesForBroker,
   getToolsForBroker,
 } from '@/lib/embed-registry';
+import { resolvePortalBrokerContext } from '@/lib/portal-broker-context';
 
 export const metadata = {
   title: 'Portal Profile | Moonshine Capital Portal',
   description: 'Broker-facing profile management and completion layer.',
 };
-
-const fallbackBrokerSlug = 'darwin-hanneman';
 
 const profileChecklist = [
   'Add positioning statement that does not sound like generic broker mush',
@@ -22,12 +21,15 @@ const profileChecklist = [
 ];
 
 export default async function PortalProfilePage() {
-  const assignedTools = await getToolsForBroker(fallbackBrokerSlug);
+  const brokerContext = await resolvePortalBrokerContext();
+  const brokerSlug = brokerContext.slug;
+
+  const assignedTools = await getToolsForBroker(brokerSlug);
   const fallbackTools = assignedTools.length > 0 ? [] : await getFeaturedRegistryItems(3);
   const recommendedTools = assignedTools.length > 0 ? assignedTools : fallbackTools;
   const recommendationMode = assignedTools.length > 0 ? 'Broker-assigned stack' : 'Fallback featured stack';
 
-  const assignedResources = await getResourcesForBroker(fallbackBrokerSlug);
+  const assignedResources = await getResourcesForBroker(brokerSlug);
   const fallbackResources = assignedResources.length > 0 ? [] : await getFeaturedResources(3);
   const recommendedResources = assignedResources.length > 0 ? assignedResources : fallbackResources;
   const resourceRecommendationMode = assignedResources.length > 0 ? 'Broker-assigned resource stack' : 'Fallback featured resource stack';
@@ -43,7 +45,7 @@ export default async function PortalProfilePage() {
           <span className="border-2 border-neo-black bg-neo-green px-3 py-1 text-xs font-black uppercase tracking-wide">Profile</span>
           <h1 className="mt-4 text-4xl font-black uppercase tracking-tight md:text-5xl">Build a profile worth sharing.</h1>
           <p className="mt-3 max-w-3xl text-base font-medium leading-relaxed text-neo-black/80">
-            This page helps brokers polish positioning, inspect assigned utility, and preview what the public actually sees. Auth-aware profile context comes later; for now this uses a safe broker-aware fallback path.
+            This page helps brokers polish positioning, inspect assigned utility, and preview what the public actually sees. Auth-aware profile context comes later; for now this uses a resolver-driven broker context path.
           </p>
         </section>
 
@@ -53,9 +55,14 @@ export default async function PortalProfilePage() {
             <div className="mt-5 border-4 border-dashed border-neo-black p-6">
               <p className="text-sm font-black uppercase tracking-wide text-neo-black/65">Preview block</p>
               <p className="mt-3 text-base font-medium leading-relaxed text-neo-black/80">
-                Current broker context: <strong>{fallbackBrokerSlug}</strong>. Replace this fallback with authenticated broker profile context once portal auth is wired.
+                Current broker context: <strong>{brokerSlug}</strong>. Context source: <strong>{brokerContext.source}</strong>. Replace the resolver fallback with authenticated broker profile context once portal auth is wired.
               </p>
-              <Link href={`/directory/${fallbackBrokerSlug}`} className="mt-4 inline-flex border-2 border-neo-black bg-neo-black px-4 py-2 text-xs font-black uppercase tracking-wide text-neo-white">
+              {brokerContext.isFallback && (
+                <p className="mt-3 inline-block border-2 border-neo-black bg-neo-yellow px-3 py-2 text-xs font-black uppercase tracking-wide">
+                  {brokerContext.label}
+                </p>
+              )}
+              <Link href={`/directory/${brokerSlug}`} className="mt-4 inline-flex border-2 border-neo-black bg-neo-black px-4 py-2 text-xs font-black uppercase tracking-wide text-neo-white">
                 Open public profile
               </Link>
             </div>

--- a/lib/portal-broker-context.ts
+++ b/lib/portal-broker-context.ts
@@ -1,0 +1,21 @@
+const fallbackBrokerSlug = 'darwin-hanneman';
+
+export type PortalBrokerContextSource = 'fallback' | 'auth';
+
+export interface PortalBrokerContext {
+  slug: string;
+  source: PortalBrokerContextSource;
+  isFallback: boolean;
+  label: string;
+}
+
+export async function resolvePortalBrokerContext(): Promise<PortalBrokerContext> {
+  // Auth/session/member-aware resolution plugs in here later.
+  // Keep this helper fallback-driven until portal auth is explicitly scoped.
+  return {
+    slug: fallbackBrokerSlug,
+    source: 'fallback',
+    isFallback: true,
+    label: 'Safe fallback broker context',
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a small `resolvePortalBrokerContext()` helper for portal profile broker context.
- Keeps the current Darwin fallback behavior isolated in one module instead of owned directly by `/portal/profile`.
- Updates `/portal/profile` to consume resolved broker context for tools, resources, preview links, and context messaging.

## Status
Closed as superseded by batch PR #100, which was squash-merged into `main`.