### PR TITLE
Convert portal profile recommendations into tracked clicks

### DIFF
--- a/app/portal/profile/page.tsx
+++ b/app/portal/profile/page.tsx
@@ -86,7 +86,7 @@ export default async function PortalProfilePage() {
               <p className="text-xs font-black uppercase tracking-wide">{recommendationMode}</p>
               <h2 className="mt-2 text-3xl font-black uppercase tracking-tight">Recommended broker tools</h2>
               <p className="mt-2 max-w-3xl font-medium text-neo-black/70">
-                These tools should be the first utility stack a broker sees when managing their profile. Tool clicks can move through tracked redirect paths once the profile action layer is fully wired.
+                These tools should be the first utility stack a broker sees when managing their profile. Primary actions now use tracked redirect paths so broker profile utility clicks are measurable.
               </p>
             </div>
             <Link href="/portal/tools" className="border-2 border-neo-black bg-neo-green px-4 py-2 text-xs font-black uppercase tracking-wide shadow-[4px_4px_0_0_rgba(0,0,0,1)]">
@@ -94,7 +94,7 @@ export default async function PortalProfilePage() {
             </Link>
           </div>
           <div className="mt-6">
-            <ToolGrid title="Profile utility stack" tools={recommendedTools.slice(0, 6)} />
+            <ToolGrid title="Profile utility stack" tools={recommendedTools.slice(0, 6)} useTrackedPrimaryActions />
           </div>
         </section>
 
@@ -104,7 +104,7 @@ export default async function PortalProfilePage() {
               <p className="text-xs font-black uppercase tracking-wide">{resourceRecommendationMode}</p>
               <h2 className="mt-2 text-3xl font-black uppercase tracking-tight">Recommended broker resources</h2>
               <p className="mt-2 max-w-3xl font-medium text-neo-black/70">
-                Scripts, guides, handoff assets, and enablement resources should sit next to the tool stack so brokers can act without hunting through another digital junk drawer.
+                Scripts, guides, handoff assets, and enablement resources should sit next to the tool stack so brokers can act without hunting through another digital junk drawer. Primary resource actions are routed through tracked redirects.
               </p>
             </div>
             <Link href="/portal/resources" className="border-2 border-neo-black bg-neo-yellow px-4 py-2 text-xs font-black uppercase tracking-wide shadow-[4px_4px_0_0_rgba(0,0,0,1)]">
@@ -117,6 +117,7 @@ export default async function PortalProfilePage() {
               tools={recommendedResources.slice(0, 6)}
               emptyTitle="No broker resources assigned yet"
               emptyCopy="Assign scripts, guides, handoff assets, or playbooks in the registry so this profile becomes useful instead of ornamental fintech wallpaper."
+              useTrackedPrimaryActions
             />
           </div>
         </section>

--- a/components/portal/ToolCard.tsx
+++ b/components/portal/ToolCard.tsx
@@ -1,16 +1,20 @@
 import Link from 'next/link';
-import type { ToolRegistryItem } from '@/lib/embed-registry';
+import { getRegistryDestination, getRegistryTrackedHref, type ToolRegistryItem } from '@/lib/embed-registry';
 
 interface ToolCardProps {
   tool: ToolRegistryItem;
+  useTrackedPrimaryAction?: boolean;
 }
 
 function getRegistryDetailHref(tool: ToolRegistryItem) {
   return tool.kind === 'resource' ? `/portal/resources/${tool.slug}` : `/portal/tools/${tool.slug}`;
 }
 
-export function ToolCard({ tool }: ToolCardProps) {
+export function ToolCard({ tool, useTrackedPrimaryAction = false }: ToolCardProps) {
   const detailHref = getRegistryDetailHref(tool);
+  const hasDestination = getRegistryDestination(tool) !== '#';
+  const primaryHref = useTrackedPrimaryAction && hasDestination ? getRegistryTrackedHref(tool) : detailHref;
+  const primaryLabel = useTrackedPrimaryAction && hasDestination ? tool.ctaLabel : 'View Details';
 
   return (
     <article className="card-brutal flex h-full flex-col gap-4 bg-neo-white text-neo-black">
@@ -42,9 +46,16 @@ export function ToolCard({ tool }: ToolCardProps) {
       </div>
 
       <div className="mt-auto flex items-center justify-between gap-3 pt-2">
-        <Link href={detailHref} className="btn-brutal-primary text-sm">
-          View Details
-        </Link>
+        <div className="flex flex-wrap items-center gap-3">
+          <Link href={primaryHref} className="btn-brutal-primary text-sm">
+            {primaryLabel}
+          </Link>
+          {useTrackedPrimaryAction && hasDestination && (
+            <Link href={detailHref} className="text-xs font-black uppercase tracking-wide text-neo-black underline decoration-2 underline-offset-4">
+              Details
+            </Link>
+          )}
+        </div>
         <span className="text-right text-xs font-bold uppercase text-neo-black/60">
           {tool.audience.slice(0, 2).join(' • ')}
         </span>

--- a/components/portal/ToolGrid.tsx
+++ b/components/portal/ToolGrid.tsx
@@ -7,6 +7,7 @@ interface ToolGridProps {
   emptyTitle?: string;
   emptyCopy?: string;
   emptyMessage?: string;
+  useTrackedPrimaryActions?: boolean;
 }
 
 export function ToolGrid({
@@ -15,6 +16,7 @@ export function ToolGrid({
   emptyTitle = 'No tools loaded yet',
   emptyCopy,
   emptyMessage,
+  useTrackedPrimaryActions = false,
 }: ToolGridProps) {
   const resolvedEmptyCopy =
     emptyMessage || emptyCopy || 'Add tools to the registry so this page becomes useful instead of decorative.';
@@ -38,7 +40,7 @@ export function ToolGrid({
       )}
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
         {tools.map((tool) => (
-          <ToolCard key={tool.id} tool={tool} />
+          <ToolCard key={tool.id} tool={tool} useTrackedPrimaryAction={useTrackedPrimaryActions} />
         ))}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Adds an opt-in tracked primary action mode to portal registry cards.
- Lets `ToolGrid` pass tracked primary actions into cards only where explicitly requested.
- Updates `/portal/profile` recommended tools/resources so primary CTAs route through `/go/[slug]` while preserving detail links.

## Status
Closed as superseded by batch PR #100, which was squash-merged into `main`.