### PR TITLE
Restore Vercel production deploys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "github": {
-    "autoAlias": false
-  }
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }


### PR DESCRIPTION
Removes github.autoAlias false from vercel.json so main can deploy to Production again.